### PR TITLE
chore(ci): add environment variable for Node.js version in code quali…

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches: [dev]
 
+env:
+    FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   lint:
     name: Run Linters


### PR DESCRIPTION
## Summary
- Added `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` environment variable at workflow level in `code-quality.yml`
- Silences the Node.js 20 deprecation warning for `actions/checkout@v4` and `actions/setup-node@v4`
- Opts the entire workflow into Node.js 24 ahead of the June 2026 GitHub Actions forced migration

## Related Issue
Part of #29

## Test Plan
- [x] No Node.js 20 deprecation warning appears in the Actions run
- [x] Both `lint` (Go) and `lint-frontend` jobs pass without warnings