### PR TITLE
[#11] RTS Camera

### DIFF
--- a/UNITY/Assets/Scenes/Game.unity
+++ b/UNITY/Assets/Scenes/Game.unity
@@ -134,6 +134,7 @@ GameObject:
   - component: {fileID: 1807679539}
   - component: {fileID: 1807679538}
   - component: {fileID: 1807679537}
+  - component: {fileID: 1807679540}
   m_Layer: 0
   m_Name: Main Camera
   m_TagString: MainCamera
@@ -206,3 +207,21 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1807679540
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1807679536}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fd1c86ae2ce139f4596d3c8ec497aab1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _panSpeed: 10
+  _edgeThreshold: 20
+  _mapBounds:
+    m_Center: {x: 0, y: 0, z: 0}
+    m_Extent: {x: 50, y: 50, z: 0}
+  _smoothing: 0.08

--- a/UNITY/Assets/Scenes/Tilemaps.unity
+++ b/UNITY/Assets/Scenes/Tilemaps.unity
@@ -18416,6 +18416,7 @@ GameObject:
   - component: {fileID: 1881693560}
   - component: {fileID: 1881693559}
   - component: {fileID: 1881693558}
+  - component: {fileID: 1881693561}
   m_Layer: 0
   m_Name: Main Camera
   m_TagString: MainCamera
@@ -18488,3 +18489,21 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1881693561
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1881693557}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fd1c86ae2ce139f4596d3c8ec497aab1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _panSpeed: 10
+  _edgeThreshold: 20
+  _mapBounds:
+    m_Center: {x: 0, y: 0, z: 0}
+    m_Extent: {x: 25, y: 25, z: 0}
+  _smoothing: 0.08

--- a/UNITY/Assets/Scenes/Tilemaps.unity
+++ b/UNITY/Assets/Scenes/Tilemaps.unity
@@ -18501,7 +18501,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: fd1c86ae2ce139f4596d3c8ec497aab1, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _panSpeed: 10
+  _panSpeed: 5
   _edgeThreshold: 20
   _mapBounds:
     m_Center: {x: 0, y: 0, z: 0}

--- a/UNITY/Assets/Scripts/Camera/CameraController.cs
+++ b/UNITY/Assets/Scripts/Camera/CameraController.cs
@@ -1,0 +1,56 @@
+using UnityEngine;
+using UnityEngine.InputSystem;
+
+public class CameraController : MonoBehaviour
+{
+    [Header("Vitesse et seuil")]
+    [SerializeField] private float _panSpeed = 10f;
+    [SerializeField] private int _edgeThreshold = 20;
+
+    [Header("Bornes de la carte")]
+    [SerializeField] private Bounds _mapBounds = new Bounds(Vector3.zero, new Vector3(50, 50, 0));
+
+    [Header("Lissage du mouvement")]
+    [SerializeField] private float _smoothing = 0.08f;
+
+    private Vector3 _targetPosition;
+
+    private void Start()
+    {
+        _targetPosition = transform.position;
+    }
+
+    private void Update()
+    {
+        Vector3 mousePos = Mouse.current.position.ReadValue();
+        Vector3 direction = Vector3.zero;
+
+        if (mousePos.x <= _edgeThreshold)
+            direction.x = -1f;
+        else if (mousePos.x >= Screen.width - _edgeThreshold)
+            direction.x = 1f;
+
+        if (mousePos.y <= _edgeThreshold)
+            direction.y = -1f;
+        else if (mousePos.y >= Screen.height - _edgeThreshold)
+            direction.y = 1f;
+
+        _targetPosition += direction * (_panSpeed * Time.deltaTime);
+
+        _targetPosition.x = Mathf.Clamp(_targetPosition.x, _mapBounds.min.x, _mapBounds.max.x);
+        _targetPosition.y = Mathf.Clamp(_targetPosition.y, _mapBounds.min.y, _mapBounds.max.y);
+
+        float t = 1f - Mathf.Pow(_smoothing, Time.deltaTime);
+        transform.position = Vector3.Lerp(transform.position, _targetPosition, t);
+    }
+
+#if UNITY_EDITOR
+    private void OnDrawGizmosSelected()
+    {
+        Gizmos.color = new Color(0f, 1f, 0.5f, 0.25f);
+        Gizmos.DrawCube(_mapBounds.center, _mapBounds.size);
+        Gizmos.color = new Color(0f, 1f, 0.5f, 1f);
+        Gizmos.DrawWireCube(_mapBounds.center, _mapBounds.size);
+    }
+#endif
+}

--- a/UNITY/Assets/Scripts/Camera/CameraController.cs
+++ b/UNITY/Assets/Scripts/Camera/CameraController.cs
@@ -3,15 +3,15 @@ using UnityEngine.InputSystem;
 
 public class CameraController : MonoBehaviour
 {
-    [Header("Vitesse et seuil")]
+    [Header("Speed & Threshold")]
     [SerializeField] private float _panSpeed = 10f;
-    [SerializeField] private int _edgeThreshold = 20;
+    [SerializeField] private int _edgeThreshold = 20; // Distance in pixels from screen edge to trigger panning
 
-    [Header("Bornes de la carte")]
+    [Header("Map Bounds")]
     [SerializeField] private Bounds _mapBounds = new Bounds(Vector3.zero, new Vector3(50, 50, 0));
 
-    [Header("Lissage du mouvement")]
-    [SerializeField] private float _smoothing = 0.08f;
+    [Header("Movement Smoothing")]
+    [SerializeField] private float _smoothing = 0.08f; // Lower = smoother, higher = snappier
 
     private Vector3 _targetPosition;
 
@@ -25,11 +25,13 @@ public class CameraController : MonoBehaviour
         Vector3 mousePos = Mouse.current.position.ReadValue();
         Vector3 direction = Vector3.zero;
 
+        // Check horizontal edges
         if (mousePos.x <= _edgeThreshold)
             direction.x = -1f;
         else if (mousePos.x >= Screen.width - _edgeThreshold)
             direction.x = 1f;
 
+        // Check vertical edges
         if (mousePos.y <= _edgeThreshold)
             direction.y = -1f;
         else if (mousePos.y >= Screen.height - _edgeThreshold)
@@ -37,14 +39,17 @@ public class CameraController : MonoBehaviour
 
         _targetPosition += direction * (_panSpeed * Time.deltaTime);
 
+        // Keep camera within map boundaries
         _targetPosition.x = Mathf.Clamp(_targetPosition.x, _mapBounds.min.x, _mapBounds.max.x);
         _targetPosition.y = Mathf.Clamp(_targetPosition.y, _mapBounds.min.y, _mapBounds.max.y);
 
+        // Framerate-independent exponential smoothing
         float t = 1f - Mathf.Pow(_smoothing, Time.deltaTime);
         transform.position = Vector3.Lerp(transform.position, _targetPosition, t);
     }
 
 #if UNITY_EDITOR
+    // Visualize map bounds in the Scene view when this object is selected
     private void OnDrawGizmosSelected()
     {
         Gizmos.color = new Color(0f, 1f, 0.5f, 0.25f);

--- a/UNITY/Assets/Scripts/Camera/CameraController.cs.meta
+++ b/UNITY/Assets/Scripts/Camera/CameraController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: fd1c86ae2ce139f4596d3c8ec497aab1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UNITY/ProjectSettings/ProjectSettings.asset
+++ b/UNITY/ProjectSettings/ProjectSettings.asset
@@ -652,7 +652,7 @@ PlayerSettings:
     m_VersionCode: 1
     m_VersionName: 
   apiCompatibilityLevel: 6
-  activeInputHandler: 1
+  activeInputHandler: 2
   windowsGamepadBackendHint: 0
   cloudProjectId: ac42b74b-ddf5-485a-8b87-3baac5ca989f
   framebufferDepthMemorylessMode: 0

--- a/UNITY/README.md
+++ b/UNITY/README.md
@@ -33,7 +33,7 @@ UNITY/
 | Tank Prefab - Movement, Cannon, HP, Respawn | [#8](https://github.com/oussema-fatnassi/WarOfTanks/issues/8) | Not started |
 | Environment - Tilemaps Setup | [#9](https://github.com/oussema-fatnassi/WarOfTanks/issues/9) | Not started |
 | Player Controls - Selection & Commands | [#10](https://github.com/oussema-fatnassi/WarOfTanks/issues/10) | Not started |
-| RTS Camera | [#11](https://github.com/oussema-fatnassi/WarOfTanks/issues/11) | Not started |
+| RTS Camera | [#11](https://github.com/oussema-fatnassi/WarOfTanks/issues/11) | Not started | ✅ 
 | Generic State Machine System | [#12](https://github.com/oussema-fatnassi/WarOfTanks/issues/12) | Not started |
 | Navigation - A* Pathfinding | [#13](https://github.com/oussema-fatnassi/WarOfTanks/issues/13) | Not started |
 | Navigation - Dijkstra | [#14](https://github.com/oussema-fatnassi/WarOfTanks/issues/14) | Not started |

--- a/UNITY/README.md
+++ b/UNITY/README.md
@@ -33,7 +33,7 @@ UNITY/
 | Tank Prefab - Movement, Cannon, HP, Respawn | [#8](https://github.com/oussema-fatnassi/WarOfTanks/issues/8) | Not started |
 | Environment - Tilemaps Setup | [#9](https://github.com/oussema-fatnassi/WarOfTanks/issues/9) | Not started |
 | Player Controls - Selection & Commands | [#10](https://github.com/oussema-fatnassi/WarOfTanks/issues/10) | Not started |
-| RTS Camera | [#11](https://github.com/oussema-fatnassi/WarOfTanks/issues/11) | Not started | ✅ 
+| RTS Camera | [#11](https://github.com/oussema-fatnassi/WarOfTanks/issues/11) | done| ✅ 
 | Generic State Machine System | [#12](https://github.com/oussema-fatnassi/WarOfTanks/issues/12) | Not started |
 | Navigation - A* Pathfinding | [#13](https://github.com/oussema-fatnassi/WarOfTanks/issues/13) | Not started |
 | Navigation - Dijkstra | [#14](https://github.com/oussema-fatnassi/WarOfTanks/issues/14) | Not started |


### PR DESCRIPTION
## Summary
- Implemented `CameraController` MonoBehaviour for top-down RTS-style edge-scrolling camera
- Camera moves when mouse cursor approaches screen edges (configurable threshold, default 20px)
- Diagonal scrolling works when cursor is in a corner
- Camera position is clamped to configurable map bounds (`Bounds _mapBounds`)
- Movement uses framerate-independent exponential smoothing via `Mathf.Pow` + `Vector3.Lerp`
- Editor Gizmo added to visualize map bounds in Scene view

## Issue
Closes #11

## Changes
- `UNITY/Assets/Scripts/Camera/CameraController.cs` — new script: edge-scroll detection, bounds clamping, smoothed movement, editor gizmo
- `UNITY/Assets/Scenes/Game.unity` — scene updated to wire CameraController to Main Camera
- `UNITY/Assets/Scenes/Tilemaps.unity` — scene updated
- `UNITY/ProjectSettings/ProjectSettings.asset` — project settings updated (Input System package)

## Definition of Done
- [x] Camera scrolls left/right/up/down when mouse approaches screen edges
- [x] Diagonal scrolling works in corners
- [x] Camera is clamped and cannot go outside map bounds
- [x] Pan speed is configurable in Inspector
- [x] Edge threshold is configurable in Inspector
- [x] Camera movement is frame-rate independent
- [x] Tested: pushing mouse to each edge scrolls correctly
- [x] Tested: camera cannot go out of bounds at any edge
- [x] Script follows naming conventions and SOLID principles

## Pre-PR Checks
- [x] SOLID principles: ✅ Pass — single responsibility respected, all camera logic self-contained
- [x] Naming conventions: ✅ Pass — PascalCase class/methods, `_camelCase` private fields, file matches class name

## Notes
- Implementation uses `UnityEngine.InputSystem` (`Mouse.current.position`) instead of the legacy `Input.mousePosition` specified in the issue — ensure the New Input System package is enabled in Project Settings
- Map bounds must be manually set in the Inspector to match the Tilemap size (as per issue requirements)
- Smoothing formula uses framerate-independent exponential decay: `1f - Mathf.Pow(_smoothing, Time.deltaTime)` — more accurate than simple lerp with `Time.deltaTime`