### PR TITLE
[#12] Generic State Machine System

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -61,6 +61,9 @@ npm run dev
 
 ### Sprint 2 — Core Gameplay
 - ✅ [#9](https://github.com/oussema-fatnassi/WarOfTanks/issues/9) Environment - Tilemaps Setup — 6 layers, collision matrix, symmetric map painted
+- ✅ [#35](https://github.com/oussema-fatnassi/WarOfTanks/issues/35) Technical Note — Figma mockups remaining (see #47)
+- ✅ [#11](https://github.com/oussema-fatnassi/WarOfTanks/issues/11) RTS Camera
+- ✅ [#12](https://github.com/oussema-fatnassi/WarOfTanks/issues/12) Generic State Machine System
 
 ## In Progress / Remaining
 
@@ -69,16 +72,13 @@ npm run dev
 | # | Title | Owner | Priority | Status |
 |---|---|---|---|---|
 | [#5](https://github.com/oussema-fatnassi/WarOfTanks/issues/5) | GitHub Actions - Backend CI | Kamelia | Critical | Not started |
-| [#35](https://github.com/oussema-fatnassi/WarOfTanks/issues/35) | Technical Note — Figma mockups remaining (see #47) | All | Critical | In progress |
 
 ### Sprint 2 — Core Gameplay (Apr 13 – Apr 19)
 
 | # | Title | Owner | Priority | Status |
 |---|---|---|---|---|
 | [#8](https://github.com/oussema-fatnassi/WarOfTanks/issues/8) | Tank Prefab - Movement, Cannon, HP, Respawn | Oroitz | Critical | In progress |
-| [#10](https://github.com/oussema-fatnassi/WarOfTanks/issues/10) | Player Controls - Selection & Commands | Oussema | Critical | Not started |
-| [#11](https://github.com/oussema-fatnassi/WarOfTanks/issues/11) | RTS Camera | Oussema | High | In progress |
-| [#12](https://github.com/oussema-fatnassi/WarOfTanks/issues/12) | Generic State Machine System | Oussema | Critical | Not started |
+| [#10](https://github.com/oussema-fatnassi/WarOfTanks/issues/10) | Player Controls - Selection & Commands | Oroitz | Critical | Not started |
 | [#29](https://github.com/oussema-fatnassi/WarOfTanks/issues/29) | Frontend Project Setup (Vite + React + TypeScript) | Oussema | Critical | In progress |
 
 ### Sprint 3 — Navigation & Backend Foundation (Apr 20 – Apr 26)

--- a/UNITY/Assets/Scenes/Tilemaps.unity
+++ b/UNITY/Assets/Scenes/Tilemaps.unity
@@ -9199,6 +9199,49 @@ TilemapCollider2D:
   m_Offset: {x: 0, y: 0}
   m_MaximumTileChangeCount: 1000
   m_ExtrusionFactor: 0.00001
+--- !u!1 &1021324473
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1021324475}
+  - component: {fileID: 1021324474}
+  m_Layer: 0
+  m_Name: Test
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1021324474
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1021324473}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 764b035d7f1a84514925c6259fb955ec, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!4 &1021324475
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1021324473}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -4.8877945, y: 2.3647776, z: -27.956144}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1122165225
 GameObject:
   m_ObjectHideFlags: 0

--- a/UNITY/Assets/Scripts/StateMachine/IState.cs
+++ b/UNITY/Assets/Scripts/StateMachine/IState.cs
@@ -1,9 +1,18 @@
 namespace WarOfTanks.StateMachine
 {
+    /// <summary>
+    /// Contract that every state in the project must implement.
+    /// The StateMachine calls these three methods to drive the state lifecycle.
+    /// </summary>
     public interface IState
     {
+        /// <summary>Called once when the state machine transitions into this state.</summary>
         void Enter();
+
+        /// <summary>Called every frame while this state is active.</summary>
         void Update();
+
+        /// <summary>Called once when the state machine transitions out of this state.</summary>
         void Exit();
     }
 }

--- a/UNITY/Assets/Scripts/StateMachine/IState.cs
+++ b/UNITY/Assets/Scripts/StateMachine/IState.cs
@@ -1,0 +1,9 @@
+namespace WarOfTanks.StateMachine
+{
+    public interface IState
+    {
+        void Enter();
+        void Update();
+        void Exit();
+    }
+}

--- a/UNITY/Assets/Scripts/StateMachine/IState.cs
+++ b/UNITY/Assets/Scripts/StateMachine/IState.cs
@@ -2,17 +2,18 @@ namespace WarOfTanks.StateMachine
 {
     /// <summary>
     /// Contract that every state in the project must implement.
+    /// T is the context (owner) passed to each method so states can read and modify it.
     /// The StateMachine calls these three methods to drive the state lifecycle.
     /// </summary>
-    public interface IState
+    public interface IState<T> where T : class
     {
         /// <summary>Called once when the state machine transitions into this state.</summary>
-        void Enter();
+        void Enter(T context);
 
         /// <summary>Called every frame while this state is active.</summary>
-        void Update();
+        void Execute(T context);
 
         /// <summary>Called once when the state machine transitions out of this state.</summary>
-        void Exit();
+        void Exit(T context);
     }
 }

--- a/UNITY/Assets/Scripts/StateMachine/IState.cs.meta
+++ b/UNITY/Assets/Scripts/StateMachine/IState.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d58c8abbef23c43efa68a2aed11f3b7e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UNITY/Assets/Scripts/StateMachine/MonoStateTest.cs
+++ b/UNITY/Assets/Scripts/StateMachine/MonoStateTest.cs
@@ -1,0 +1,28 @@
+using UnityEngine;
+using UnityEngine.InputSystem;
+using WarOfTanks.StateMachine;
+
+public class MonoStateTest : MonoBehaviour
+{
+    StateMachine<MonoStateTest> _sm;
+
+    private void Awake()
+    {
+        _sm = new StateMachine<MonoStateTest>(this);
+    }
+
+    private void Start()
+    {
+        _sm.SetState(new StateA());
+    }
+
+    private void Update()
+    {
+        _sm.Update();
+        if (Keyboard.current.spaceKey.wasPressedThisFrame)
+        {
+            _sm.SetState(new StateB());
+        }
+    }
+}
+        

--- a/UNITY/Assets/Scripts/StateMachine/MonoStateTest.cs
+++ b/UNITY/Assets/Scripts/StateMachine/MonoStateTest.cs
@@ -8,12 +8,7 @@ public class MonoStateTest : MonoBehaviour
 
     private void Awake()
     {
-        _sm = new StateMachine<MonoStateTest>(this);
-    }
-
-    private void Start()
-    {
-        _sm.SetState(new StateA());
+        _sm = new StateMachine<MonoStateTest>(this, new StateA());
     }
 
     private void Update()
@@ -21,8 +16,7 @@ public class MonoStateTest : MonoBehaviour
         _sm.Update();
         if (Keyboard.current.spaceKey.wasPressedThisFrame)
         {
-            _sm.SetState(new StateB());
+            _sm.ChangeState(new StateB());
         }
     }
 }
-        

--- a/UNITY/Assets/Scripts/StateMachine/MonoStateTest.cs.meta
+++ b/UNITY/Assets/Scripts/StateMachine/MonoStateTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 764b035d7f1a84514925c6259fb955ec
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UNITY/Assets/Scripts/StateMachine/StateA.cs
+++ b/UNITY/Assets/Scripts/StateMachine/StateA.cs
@@ -1,21 +1,20 @@
-// test state machine
-
+// Smoke test state — remove once real states are implemented
 using UnityEngine;
 using WarOfTanks.StateMachine;
 
-public class StateA : IState
+public class StateA : IState<MonoStateTest>
 {
-    public void Enter()
+    public void Enter(MonoStateTest context)
     {
         Debug.Log("State A Entered");
     }
 
-    public void Update()
+    public void Execute(MonoStateTest context)
     {
-        Debug.Log("State A Updated");
+        Debug.Log("State A Executing");
     }
 
-    public void Exit()
+    public void Exit(MonoStateTest context)
     {
         Debug.Log("State A Exited");
     }

--- a/UNITY/Assets/Scripts/StateMachine/StateA.cs
+++ b/UNITY/Assets/Scripts/StateMachine/StateA.cs
@@ -1,0 +1,22 @@
+// test state machine
+
+using UnityEngine;
+using WarOfTanks.StateMachine;
+
+public class StateA : IState
+{
+    public void Enter()
+    {
+        Debug.Log("State A Entered");
+    }
+
+    public void Update()
+    {
+        Debug.Log("State A Updated");
+    }
+
+    public void Exit()
+    {
+        Debug.Log("State A Exited");
+    }
+}

--- a/UNITY/Assets/Scripts/StateMachine/StateA.cs.meta
+++ b/UNITY/Assets/Scripts/StateMachine/StateA.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c94c90eb16a154893b75d0ab8cbef698
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UNITY/Assets/Scripts/StateMachine/StateB.cs
+++ b/UNITY/Assets/Scripts/StateMachine/StateB.cs
@@ -1,0 +1,20 @@
+using UnityEngine;
+using WarOfTanks.StateMachine;
+
+public class StateB : IState
+{
+    public void Enter()
+    {
+        Debug.Log("State B Entered");
+    }
+
+    public void Update()
+    {
+        Debug.Log("State B Updated");
+    }
+
+    public void Exit()
+    {
+        Debug.Log("State B Exited");
+    }
+}

--- a/UNITY/Assets/Scripts/StateMachine/StateB.cs
+++ b/UNITY/Assets/Scripts/StateMachine/StateB.cs
@@ -1,19 +1,20 @@
+// Smoke test state — remove once real states are implemented
 using UnityEngine;
 using WarOfTanks.StateMachine;
 
-public class StateB : IState
+public class StateB : IState<MonoStateTest>
 {
-    public void Enter()
+    public void Enter(MonoStateTest context)
     {
         Debug.Log("State B Entered");
     }
 
-    public void Update()
+    public void Execute(MonoStateTest context)
     {
-        Debug.Log("State B Updated");
+        Debug.Log("State B Executing");
     }
 
-    public void Exit()
+    public void Exit(MonoStateTest context)
     {
         Debug.Log("State B Exited");
     }

--- a/UNITY/Assets/Scripts/StateMachine/StateB.cs.meta
+++ b/UNITY/Assets/Scripts/StateMachine/StateB.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8d27426e31030485eb6e3fd407f5e882
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UNITY/Assets/Scripts/StateMachine/StateMachine.cs
+++ b/UNITY/Assets/Scripts/StateMachine/StateMachine.cs
@@ -1,15 +1,31 @@
 namespace WarOfTanks.StateMachine
 {
+    /// <summary>
+    /// Generic, reusable state machine. T is the owner — the object whose behaviour
+    /// is being controlled (e.g. Tank, ControlZone). T must be a reference type
+    /// because all owners in this project are MonoBehaviours.
+    ///
+    /// Usage: instantiate with the owner, call SetState() to enter the first state,
+    /// then call Update() every frame from the owner's MonoBehaviour.Update().
+    /// </summary>
     public class StateMachine<T> where T : class
     {
+        // The state currently running. Null until SetState is called for the first time.
         private IState _currentState;
+
+        // Reference to the object this machine controls. Passed to states via their constructors.
         private T _owner;
 
+        /// <summary>Creates a new state machine bound to the given owner.</summary>
         public StateMachine(T owner)
         {
             _owner = owner;
         }
 
+        /// <summary>
+        /// Transitions to a new state. Calls Exit() on the current state (if any),
+        /// then calls Enter() on the new state. This is the only way to change state.
+        /// </summary>
         public void SetState(IState newState)
         {
             _currentState?.Exit();
@@ -17,11 +33,16 @@ namespace WarOfTanks.StateMachine
             _currentState.Enter();
         }
 
+        /// <summary>
+        /// Forwards the update tick to the current state.
+        /// Call this from the owner's MonoBehaviour.Update() every frame.
+        /// </summary>
         public void Update()
         {
             _currentState?.Update();
         }
 
+        /// <summary>Returns the state currently active in the machine.</summary>
         public IState GetCurrentState()
         {
             return _currentState;

--- a/UNITY/Assets/Scripts/StateMachine/StateMachine.cs
+++ b/UNITY/Assets/Scripts/StateMachine/StateMachine.cs
@@ -1,49 +1,52 @@
 namespace WarOfTanks.StateMachine
 {
     /// <summary>
-    /// Generic, reusable state machine. T is the owner — the object whose behaviour
+    /// Generic, reusable state machine. T is the context — the object whose behaviour
     /// is being controlled (e.g. Tank, ControlZone). T must be a reference type
-    /// because all owners in this project are MonoBehaviours.
+    /// because all contexts in this project are MonoBehaviours.
     ///
-    /// Usage: instantiate with the owner, call SetState() to enter the first state,
-    /// then call Update() every frame from the owner's MonoBehaviour.Update().
+    /// Usage: instantiate with the context and initial state, then call Update()
+    /// every frame from the context's MonoBehaviour.Update().
     /// </summary>
     public class StateMachine<T> where T : class
     {
-        // The state currently running. Null until SetState is called for the first time.
-        private IState _currentState;
+        // The state currently running. Set immediately by the constructor.
+        private IState<T> _currentState;
 
-        // Reference to the object this machine controls. Passed to states via their constructors.
-        private T _owner;
+        // Reference to the object this machine controls. Passed into every state method call.
+        private T _context;
 
-        /// <summary>Creates a new state machine bound to the given owner.</summary>
-        public StateMachine(T owner)
+        /// <summary>
+        /// Creates a new state machine bound to the given context and enters the initial state immediately.
+        /// </summary>
+        public StateMachine(T context, IState<T> initialState)
         {
-            _owner = owner;
+            _context = context;
+            ChangeState(initialState);
         }
 
         /// <summary>
         /// Transitions to a new state. Calls Exit() on the current state (if any),
         /// then calls Enter() on the new state. This is the only way to change state.
         /// </summary>
-        public void SetState(IState newState)
+        public void ChangeState(IState<T> newState)
         {
-            _currentState?.Exit();
+            _currentState?.Exit(_context);
             _currentState = newState;
-            _currentState.Enter();
+            _currentState.Enter(_context);
         }
 
         /// <summary>
-        /// Forwards the update tick to the current state.
-        /// Call this from the owner's MonoBehaviour.Update() every frame.
+        /// Forwards the update tick to the current state via Execute().
+        /// Call this from the context's MonoBehaviour.Update() every frame.
         /// </summary>
         public void Update()
         {
-            _currentState?.Update();
+            _currentState?.Execute(_context);
         }
 
         /// <summary>Returns the state currently active in the machine.</summary>
-        public IState GetCurrentState()
+        public IState<T> GetCurrentState()
         {
             return _currentState;
         }

--- a/UNITY/Assets/Scripts/StateMachine/StateMachine.cs
+++ b/UNITY/Assets/Scripts/StateMachine/StateMachine.cs
@@ -1,0 +1,30 @@
+namespace WarOfTanks.StateMachine
+{
+    public class StateMachine<T> where T : class
+    {
+        private IState _currentState;
+        private T _owner;
+
+        public StateMachine(T owner)
+        {
+            _owner = owner;
+        }
+
+        public void SetState(IState newState)
+        {
+            _currentState?.Exit();
+            _currentState = newState;
+            _currentState.Enter();
+        }
+
+        public void Update()
+        {
+            _currentState?.Update();
+        }
+
+        public IState GetCurrentState()
+        {
+            return _currentState;
+        }
+    }
+}

--- a/UNITY/Assets/Scripts/StateMachine/StateMachine.cs.meta
+++ b/UNITY/Assets/Scripts/StateMachine/StateMachine.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f256594c7271640628ac95db856f6ad5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UNITY/Assets/Scripts/StateMachine/WarOfTanks.StateMachine.asmdef
+++ b/UNITY/Assets/Scripts/StateMachine/WarOfTanks.StateMachine.asmdef
@@ -1,0 +1,6 @@
+{
+    "name": "WarOfTanks.StateMachine",
+    "references": [
+        "Unity.InputSystem"
+    ]
+}

--- a/UNITY/Assets/Scripts/StateMachine/WarOfTanks.StateMachine.asmdef.meta
+++ b/UNITY/Assets/Scripts/StateMachine/WarOfTanks.StateMachine.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 6397435bcf2134e8190d01c9508a1ea5
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UNITY/Assets/Tests.meta
+++ b/UNITY/Assets/Tests.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: d51a7ab24992f4e57bdb63a84ee7c822
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UNITY/Assets/Tests/DummyOwner.cs
+++ b/UNITY/Assets/Tests/DummyOwner.cs
@@ -1,0 +1,4 @@
+class DummyOwner
+{
+    
+}

--- a/UNITY/Assets/Tests/DummyOwner.cs.meta
+++ b/UNITY/Assets/Tests/DummyOwner.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d1c41d736d5624c8cb8732f8145d7906
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UNITY/Assets/Tests/MockState.cs
+++ b/UNITY/Assets/Tests/MockState.cs
@@ -1,0 +1,23 @@
+using WarOfTanks.StateMachine;
+    
+class MockState : IState
+{
+    public int enterCount;
+    public int updateCount;
+    public int exitCount;
+
+    public void Enter()
+    {
+        enterCount++;
+    }
+
+    public void Update()
+    {
+        updateCount++;
+    }
+
+    public void Exit()
+    {
+        exitCount++;
+    }
+}

--- a/UNITY/Assets/Tests/MockState.cs
+++ b/UNITY/Assets/Tests/MockState.cs
@@ -1,22 +1,22 @@
 using WarOfTanks.StateMachine;
-    
-class MockState : IState
+
+class MockState : IState<DummyOwner>
 {
     public int enterCount;
-    public int updateCount;
+    public int executeCount;
     public int exitCount;
 
-    public void Enter()
+    public void Enter(DummyOwner context)
     {
         enterCount++;
     }
 
-    public void Update()
+    public void Execute(DummyOwner context)
     {
-        updateCount++;
+        executeCount++;
     }
 
-    public void Exit()
+    public void Exit(DummyOwner context)
     {
         exitCount++;
     }

--- a/UNITY/Assets/Tests/MockState.cs.meta
+++ b/UNITY/Assets/Tests/MockState.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4ee5d0048736b49b18d362313a8bce37
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UNITY/Assets/Tests/StateMachineTests.cs
+++ b/UNITY/Assets/Tests/StateMachineTests.cs
@@ -1,0 +1,75 @@
+using NUnit.Framework;
+using WarOfTanks.StateMachine;
+
+public class StateMachineTests
+{
+    [Test]
+    public void GetCurrentState_ReturnsNull_WhenNoStateHasBeenSet()
+    {
+        var owner = new DummyOwner();
+        var stateMachine = new StateMachine<DummyOwner>(owner);
+
+        var currentState = stateMachine.GetCurrentState();
+
+        Assert.IsNull(currentState);
+    }
+
+    [Test]
+    public void SetState_SetsCurrentState_AndCallsEnterOnNewState()
+    {
+        var owner = new DummyOwner();
+        var stateMachine = new StateMachine<DummyOwner>(owner);
+        var newState = new MockState();
+
+        stateMachine.SetState(newState);
+
+        Assert.AreSame(newState, stateMachine.GetCurrentState());
+        Assert.AreEqual(1, newState.enterCount);
+        Assert.AreEqual(0, newState.exitCount);
+        Assert.AreEqual(0, newState.updateCount);
+    }
+
+    [Test]
+    public void Update_CallsUpdateOnCurrentState()
+    {
+        var owner = new DummyOwner();
+        var stateMachine = new StateMachine<DummyOwner>(owner);
+        var currentState = new MockState();
+        stateMachine.SetState(currentState);
+
+        stateMachine.Update();
+
+        Assert.AreEqual(1, currentState.updateCount);
+        Assert.AreEqual(1, currentState.enterCount);
+        Assert.AreEqual(0, currentState.exitCount);
+    }
+
+    [Test]
+    public void SetState_ExitsPreviousState_AndEntersNewState()
+    {
+        var owner = new DummyOwner();
+        var stateMachine = new StateMachine<DummyOwner>(owner);
+        var previousState = new MockState();
+        var nextState = new MockState();
+        stateMachine.SetState(previousState);
+
+        stateMachine.SetState(nextState);
+
+        Assert.AreSame(nextState, stateMachine.GetCurrentState());
+        Assert.AreEqual(1, previousState.enterCount);
+        Assert.AreEqual(1, previousState.exitCount);
+        Assert.AreEqual(1, nextState.enterCount);
+        Assert.AreEqual(0, nextState.exitCount);
+    }
+
+    [Test]
+    public void Update_DoesNotThrow_WhenNoCurrentStateExists()
+    {
+        var owner = new DummyOwner();
+        var stateMachine = new StateMachine<DummyOwner>(owner);
+
+        TestDelegate updateWithoutState = () => stateMachine.Update();
+
+        Assert.DoesNotThrow(updateWithoutState);
+    }
+}

--- a/UNITY/Assets/Tests/StateMachineTests.cs
+++ b/UNITY/Assets/Tests/StateMachineTests.cs
@@ -4,56 +4,42 @@ using WarOfTanks.StateMachine;
 public class StateMachineTests
 {
     [Test]
-    public void GetCurrentState_ReturnsNull_WhenNoStateHasBeenSet()
+    public void Constructor_SetsInitialState_AndCallsEnter()
     {
         var owner = new DummyOwner();
-        var stateMachine = new StateMachine<DummyOwner>(owner);
+        var initialState = new MockState();
 
-        var currentState = stateMachine.GetCurrentState();
+        var stateMachine = new StateMachine<DummyOwner>(owner, initialState);
 
-        Assert.IsNull(currentState);
+        Assert.AreSame(initialState, stateMachine.GetCurrentState());
+        Assert.AreEqual(1, initialState.enterCount);
+        Assert.AreEqual(0, initialState.exitCount);
+        Assert.AreEqual(0, initialState.executeCount);
     }
 
     [Test]
-    public void SetState_SetsCurrentState_AndCallsEnterOnNewState()
+    public void Update_CallsExecuteOnCurrentState()
     {
         var owner = new DummyOwner();
-        var stateMachine = new StateMachine<DummyOwner>(owner);
-        var newState = new MockState();
-
-        stateMachine.SetState(newState);
-
-        Assert.AreSame(newState, stateMachine.GetCurrentState());
-        Assert.AreEqual(1, newState.enterCount);
-        Assert.AreEqual(0, newState.exitCount);
-        Assert.AreEqual(0, newState.updateCount);
-    }
-
-    [Test]
-    public void Update_CallsUpdateOnCurrentState()
-    {
-        var owner = new DummyOwner();
-        var stateMachine = new StateMachine<DummyOwner>(owner);
         var currentState = new MockState();
-        stateMachine.SetState(currentState);
+        var stateMachine = new StateMachine<DummyOwner>(owner, currentState);
 
         stateMachine.Update();
 
-        Assert.AreEqual(1, currentState.updateCount);
+        Assert.AreEqual(1, currentState.executeCount);
         Assert.AreEqual(1, currentState.enterCount);
         Assert.AreEqual(0, currentState.exitCount);
     }
 
     [Test]
-    public void SetState_ExitsPreviousState_AndEntersNewState()
+    public void ChangeState_ExitsPreviousState_AndEntersNewState()
     {
         var owner = new DummyOwner();
-        var stateMachine = new StateMachine<DummyOwner>(owner);
         var previousState = new MockState();
         var nextState = new MockState();
-        stateMachine.SetState(previousState);
+        var stateMachine = new StateMachine<DummyOwner>(owner, previousState);
 
-        stateMachine.SetState(nextState);
+        stateMachine.ChangeState(nextState);
 
         Assert.AreSame(nextState, stateMachine.GetCurrentState());
         Assert.AreEqual(1, previousState.enterCount);
@@ -63,13 +49,16 @@ public class StateMachineTests
     }
 
     [Test]
-    public void Update_DoesNotThrow_WhenNoCurrentStateExists()
+    public void Update_CallsExecuteWithCorrectContext()
     {
         var owner = new DummyOwner();
-        var stateMachine = new StateMachine<DummyOwner>(owner);
+        var state = new MockState();
+        var stateMachine = new StateMachine<DummyOwner>(owner, state);
 
-        TestDelegate updateWithoutState = () => stateMachine.Update();
+        stateMachine.Update();
+        stateMachine.Update();
+        stateMachine.Update();
 
-        Assert.DoesNotThrow(updateWithoutState);
+        Assert.AreEqual(3, state.executeCount);
     }
 }

--- a/UNITY/Assets/Tests/StateMachineTests.cs.meta
+++ b/UNITY/Assets/Tests/StateMachineTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 963dffae8f7b6429e9ec817bf3017db0
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UNITY/Assets/Tests/Tests.asmdef
+++ b/UNITY/Assets/Tests/Tests.asmdef
@@ -1,0 +1,12 @@
+{
+    "name": "Tests",
+    "references": [
+        "WarOfTanks.StateMachine"
+    ],
+    "optionalUnityReferences": [
+        "TestAssemblies"
+    ],
+    "includePlatforms": [
+        "Editor"
+    ]
+}

--- a/UNITY/Assets/Tests/Tests.asmdef.meta
+++ b/UNITY/Assets/Tests/Tests.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 04a3c33c99cad456a9d5c4a7f85b9b78
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UNITY/README.md
+++ b/UNITY/README.md
@@ -37,8 +37,8 @@ UNITY/
 | Tank Prefab - Movement, Cannon, HP, Respawn | [#8](https://github.com/oussema-fatnassi/WarOfTanks/issues/8) | In progress |
 | Environment - Tilemaps Setup | [#9](https://github.com/oussema-fatnassi/WarOfTanks/issues/9) | ✅ Done |
 | Player Controls - Selection & Commands | [#10](https://github.com/oussema-fatnassi/WarOfTanks/issues/10) | Not started |
-| RTS Camera | [#11](https://github.com/oussema-fatnassi/WarOfTanks/issues/11) | done| ✅ 
-| Generic State Machine System | [#12](https://github.com/oussema-fatnassi/WarOfTanks/issues/12) | Not started |
+| RTS Camera | [#11](https://github.com/oussema-fatnassi/WarOfTanks/issues/11) | ✅ Done |
+| Generic State Machine System | [#12](https://github.com/oussema-fatnassi/WarOfTanks/issues/12) | ✅ Done |
 | Navigation - A* Pathfinding | [#13](https://github.com/oussema-fatnassi/WarOfTanks/issues/13) | Not started |
 | Navigation - Dijkstra | [#14](https://github.com/oussema-fatnassi/WarOfTanks/issues/14) | Not started |
 | Navigation - Flow Field | [#15](https://github.com/oussema-fatnassi/WarOfTanks/issues/15) | Not started |


### PR DESCRIPTION
## Summary
- Implemented `IState<T>` generic interface with `Enter(T context)`, `Execute(T context)`, `Exit(T context)` — aligned with UML class diagram
- Implemented `StateMachine<T>` generic class with `where T : class` constraint
- Constructor takes both `context` and `initialState` — machine enters the initial state immediately on creation
- `ChangeState()` calls `Exit(context)` on the previous state and `Enter(context)` on the new state
- Context is passed as a parameter on every method call — states are stateless and hold no references
- Added `WarOfTanks.StateMachine` assembly definition for clean namespace isolation
- Added smoke test (`MonoStateTest`) verifying A→B transition via Space key in Play mode
- Added Unity Test Runner EditMode suite: 4 tests covering constructor/initial state, transition lifecycle, update delegation, and multi-frame execute count

## Issue
Closes #12

## Changes
- `Assets/Scripts/StateMachine/IState.cs` — generic `IState<T>` interface with `Enter/Execute/Exit(T context)` and XML doc comments
- `Assets/Scripts/StateMachine/StateMachine.cs` — `StateMachine<T>` with `_context` field, `ChangeState()`, constructor entering initial state, and XML doc comments
- `Assets/Scripts/StateMachine/WarOfTanks.StateMachine.asmdef` — assembly definition scoping the namespace
- `Assets/Scripts/StateMachine/MonoStateTest.cs` — MonoBehaviour smoke test (Space key triggers A→B via `ChangeState`)
- `Assets/Scripts/StateMachine/StateA.cs` / `StateB.cs` — dummy states implementing `IState<MonoStateTest>` for smoke testing
- `Assets/Tests/StateMachineTests.cs` — 4 NUnit EditMode tests (AAA pattern)
- `Assets/Tests/MockState.cs` — mock implementing `IState<DummyOwner>` with `enterCount`, `executeCount`, `exitCount`
- `Assets/Tests/DummyOwner.cs` — minimal owner class for `StateMachine<DummyOwner>` in tests
- `Assets/Tests/Tests.asmdef` — test assembly referencing `WarOfTanks.StateMachine`
- `README.md` / `UNITY/README.md` — status updated to reflect #11 and #12 as done

## Definition of Done
- [x] `IState<T>` interface created with `Enter(T context)`, `Execute(T context)`, `Exit(T context)`
- [x] `StateMachine<T>` generic class created
- [x] `ChangeState()` calls `Exit(context)` on the old state and `Enter(context)` on the new state
- [x] `Update()` correctly delegates to the current state's `Execute(context)`
- [x] Simple test written — smoke test in Editor + 4 Unity Test Runner EditMode tests
- [x] No Unity-specific dependencies in the state machine code (pure C#)
- [x] SOLID check passed — Single Responsibility and Open/Closed confirmed
- [x] Files in the correct `Assets/Scripts/StateMachine/` folder

## Pre-PR Checks
- [x] SOLID principles: ✅ Pass — IState<T> and StateMachine<T> both have single responsibilities, machine depends on IState<T> abstraction only
- [x] Naming conventions: ✅ Pass — I-prefix on interface, underscore-prefix on private fields, PascalCase public members
- [x] Documentation: ✅ Pass on production files — XML doc comments on all public members of IState<T> and StateMachine<T>

## Notes
- API fully aligned with the UML class diagram (`IState<T>`, `Enter/Execute/Exit` with context parameter, `ChangeState`, `_context` field)
- States are stateless — they receive the context on every call and hold no stored references, which makes them easier to test and reuse
- `MonoStateTest`, `StateA`, `StateB` are temporary smoke test files — can be removed once real tank and zone states are implemented in Sprint 3
- This system directly unblocks #17 (Control Zone State Machine)