### PR TITLE
[#13] Navigation - A* Pathfinding

### DIFF
--- a/UNITY/Assets/Scenes/Tilemaps.unity
+++ b/UNITY/Assets/Scenes/Tilemaps.unity
@@ -147,7 +147,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 32041722}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 10.35, y: 10.6, z: 0}
+  m_LocalPosition: {x: 11.79, y: 11.34, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
@@ -180,7 +180,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 62230669}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalPosition: {x: -0.5, y: 6.5, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 1122165227}
@@ -479,7 +479,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 90976985}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalPosition: {x: -0.5, y: 6.5, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 1122165227}
@@ -877,7 +877,7 @@ TilemapCollider2D:
   m_Material: {fileID: 0}
   m_IsTrigger: 0
   m_UsedByEffector: 0
-  m_UsedByComposite: 1
+  m_UsedByComposite: 0
   m_Offset: {x: 0, y: 0}
   m_MaximumTileChangeCount: 1000
   m_ExtrusionFactor: 0.00001
@@ -892,6 +892,7 @@ GameObject:
   - component: {fileID: 139854044}
   - component: {fileID: 139854046}
   - component: {fileID: 139854045}
+  - component: {fileID: 139854047}
   m_Layer: 6
   m_Name: Ground_Walkable
   m_TagString: Untagged
@@ -907,7 +908,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 139854043}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalPosition: {x: -0.5, y: 6.5, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 1122165227}
@@ -7997,6 +7998,22 @@ Tilemap:
     e31: 0
     e32: 0
     e33: 1
+--- !u!19719996 &139854047
+TilemapCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 139854043}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  m_MaximumTileChangeCount: 1000
+  m_ExtrusionFactor: 0.00001
 --- !u!1001 &265081314
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -8022,11 +8039,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 773176152485814612, guid: 8c3bdc1bc81e82f49acf03aaac5e8b65, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 2.71
+      value: 11.61
       objectReference: {fileID: 0}
     - target: {fileID: 773176152485814612, guid: 8c3bdc1bc81e82f49acf03aaac5e8b65, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 3.99
+      value: 1.65
       objectReference: {fileID: 0}
     - target: {fileID: 773176152485814612, guid: 8c3bdc1bc81e82f49acf03aaac5e8b65, type: 3}
       propertyPath: m_LocalPosition.z
@@ -8107,11 +8124,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 773176152485814612, guid: 8c3bdc1bc81e82f49acf03aaac5e8b65, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -6.48
+      value: -6.72
       objectReference: {fileID: 0}
     - target: {fileID: 773176152485814612, guid: 8c3bdc1bc81e82f49acf03aaac5e8b65, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 3.1
+      value: 4.36
       objectReference: {fileID: 0}
     - target: {fileID: 773176152485814612, guid: 8c3bdc1bc81e82f49acf03aaac5e8b65, type: 3}
       propertyPath: m_LocalPosition.z
@@ -8185,7 +8202,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 305643270}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalPosition: {x: -0.5, y: 6.5, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 1122165227}
@@ -8807,15 +8824,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 715619301374867557, guid: fc9b9e06826407d4db2f62253cfa4043, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -1.5469708
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 715619301374867557, guid: fc9b9e06826407d4db2f62253cfa4043, type: 3}
       propertyPath: m_LocalPosition.y
-      value: -1.7774643
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 715619301374867557, guid: fc9b9e06826407d4db2f62253cfa4043, type: 3}
       propertyPath: m_LocalPosition.z
-      value: -22.666386
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 715619301374867557, guid: fc9b9e06826407d4db2f62253cfa4043, type: 3}
       propertyPath: m_LocalRotation.w
@@ -8887,7 +8904,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 929048190}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalPosition: {x: -0.5, y: 6.5, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 1122165227}
@@ -9463,7 +9480,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1008525846}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -3.93, y: 7.85, z: 0}
+  m_LocalPosition: {x: 7.03, y: -7.69, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
@@ -9492,6 +9509,7 @@ GameObject:
   - component: {fileID: 1122165226}
   - component: {fileID: 1122165229}
   - component: {fileID: 1122165228}
+  - component: {fileID: 1122165230}
   m_Layer: 0
   m_Name: Grid
   m_TagString: Untagged
@@ -9519,7 +9537,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1122165225}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -0.69, y: 6.29, z: 0}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 1374103584}
@@ -9548,179 +9566,9 @@ CompositeCollider2D:
   m_GeometryType: 0
   m_GenerationType: 0
   m_EdgeRadius: 0
-  m_ColliderPaths:
-  - m_Collider: {fileID: 90976989}
-    m_ColliderPaths:
-    - - X: -19999900
-        Y: -10000041
-      - X: -19999900
-        Y: 20000041
-      - X: -19999959
-        Y: 20000100
-      - X: -30000041
-        Y: 20000100
-      - X: -30000100
-        Y: 20000041
-      - X: -30000100
-        Y: 10000100
-      - X: -40000041
-        Y: 10000100
-      - X: -40000100
-        Y: 10000041
-      - X: -40000100
-        Y: 100
-      - X: -50000041
-        Y: 100
-      - X: -50000100
-        Y: 41
-      - X: -50000100
-        Y: -10000041
-      - X: -50000041
-        Y: -10000100
-      - X: -19999959
-        Y: -10000100
-    - - X: 50000100
-        Y: -20000041
-      - X: 50000100
-        Y: 41
-      - X: 50000041
-        Y: 100
-      - X: 19999959
-        Y: 100
-      - X: 19999900
-        Y: 41
-      - X: 19999900
-        Y: -10000041
-      - X: 19999959
-        Y: -10000100
-      - X: 39999900
-        Y: -10000100
-      - X: 39999900
-        Y: -20000041
-      - X: 39999959
-        Y: -20000100
-      - X: 50000041
-        Y: -20000100
-    - - X: -69999900
-        Y: -70000041
-      - X: -69999900
-        Y: -59999959
-      - X: -69999959
-        Y: -59999900
-      - X: -110000041
-        Y: -59999900
-      - X: -110000100
-        Y: -59999959
-      - X: -110000100
-        Y: -70000041
-      - X: -110000041
-        Y: -70000100
-      - X: -69999959
-        Y: -70000100
-    - - X: 130000100
-        Y: -70000041
-      - X: 130000100
-        Y: -59999959
-      - X: 130000041
-        Y: -59999900
-      - X: 89999959
-        Y: -59999900
-      - X: 89999900
-        Y: -59999959
-      - X: 89999900
-        Y: -70000041
-      - X: 89999959
-        Y: -70000100
-      - X: 130000041
-        Y: -70000100
-    - - X: -9999900
-        Y: -120000041
-      - X: -9999900
-        Y: -109999959
-      - X: -9999959
-        Y: -109999900
-      - X: -29999900
-        Y: -109999900
-      - X: -29999900
-        Y: -99999959
-      - X: -29999959
-        Y: -99999900
-      - X: -40000041
-        Y: -99999900
-      - X: -40000100
-        Y: -99999959
-      - X: -40000100
-        Y: -120000041
-      - X: -40000041
-        Y: -120000100
-      - X: -9999959
-        Y: -120000100
-    - - X: 50000100
-        Y: -130000041
-      - X: 50000100
-        Y: -120000100
-      - X: 60000041
-        Y: -120000100
-      - X: 60000100
-        Y: -120000041
-      - X: 60000100
-        Y: -109999959
-      - X: 60000041
-        Y: -109999900
-      - X: 39999959
-        Y: -109999900
-      - X: 39999900
-        Y: -109999959
-      - X: 39999900
-        Y: -119999900
-      - X: 19999959
-        Y: -119999900
-      - X: 19999900
-        Y: -119999959
-      - X: 19999900
-        Y: -130000041
-      - X: 19999959
-        Y: -130000100
-      - X: 50000041
-        Y: -130000100
+  m_ColliderPaths: []
   m_CompositePaths:
-    m_Paths:
-    - - {x: -2.0000253, y: -1.00001}
-      - {x: -2.0000253, y: 2.00001}
-      - {x: -3.00001, y: 1.9999748}
-      - {x: -3.0000393, y: 1.00001}
-      - {x: -4.00001, y: 0.9999748}
-      - {x: -4.000039, y: 0.00001}
-      - {x: -5.00001, y: -0.0000252}
-      - {x: -4.9999747, y: -1.00001}
-    - - {x: 4.9999747, y: -2.00001}
-      - {x: 4.9999747, y: 0.00001}
-      - {x: 1.99999, y: -0.0000252}
-      - {x: 2.0000253, y: -1.00001}
-      - {x: 3.99999, y: -1.0000395}
-      - {x: 4.0000253, y: -2.00001}
-    - - {x: -7.0000257, y: -7.0000095}
-      - {x: -7.0000257, y: -5.99999}
-      - {x: -11.00001, y: -6.0000253}
-      - {x: -10.999974, y: -7.0000095}
-    - - {x: 12.999974, y: -7.0000095}
-      - {x: 12.999974, y: -5.99999}
-      - {x: 8.99999, y: -6.0000253}
-      - {x: 9.000026, y: -7.0000095}
-    - - {x: -1.0000252, y: -12.00001}
-      - {x: -1.0000252, y: -10.99999}
-      - {x: -2.99999, y: -10.999961}
-      - {x: -3.0000253, y: -9.99999}
-      - {x: -4.00001, y: -10.000026}
-      - {x: -3.9999747, y: -12.00001}
-    - - {x: 4.9999747, y: -13.00001}
-      - {x: 5.000039, y: -12.00001}
-      - {x: 6.00001, y: -11.999974}
-      - {x: 5.9999747, y: -10.99999}
-      - {x: 3.99999, y: -11.000026}
-      - {x: 3.999961, y: -11.99999}
-      - {x: 1.99999, y: -12.000026}
-      - {x: 2.0000253, y: -13.00001}
+    m_Paths: []
   m_VertexDistance: 0.0005
   m_OffsetDistance: 0.00005
 --- !u!50 &1122165229
@@ -9744,6 +9592,27 @@ Rigidbody2D:
   m_SleepingMode: 1
   m_CollisionDetection: 0
   m_Constraints: 0
+--- !u!114 &1122165230
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1122165225}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 986cf6282ca4d4c32b11ab8a1b728f98, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _width: 29
+  _height: 29
+  _cellSize: 1
+  _walkableLayer:
+    serializedVersion: 2
+    m_Bits: 64
+  _unwalkableLayer:
+    serializedVersion: 2
+    m_Bits: 1664
 --- !u!1 &1374103583
 GameObject:
   m_ObjectHideFlags: 0
@@ -9755,7 +9624,7 @@ GameObject:
   - component: {fileID: 1374103584}
   - component: {fileID: 1374103586}
   - component: {fileID: 1374103585}
-  m_Layer: 0
+  m_Layer: 7
   m_Name: Background
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -9770,7 +9639,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1374103583}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalPosition: {x: -0.5, y: 6.5, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 1122165227}

--- a/UNITY/Assets/Scenes/Tilemaps.unity
+++ b/UNITY/Assets/Scenes/Tilemaps.unity
@@ -8039,11 +8039,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 773176152485814612, guid: 8c3bdc1bc81e82f49acf03aaac5e8b65, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 11.61
+      value: 4.53
       objectReference: {fileID: 0}
     - target: {fileID: 773176152485814612, guid: 8c3bdc1bc81e82f49acf03aaac5e8b65, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 1.65
+      value: -2.18
       objectReference: {fileID: 0}
     - target: {fileID: 773176152485814612, guid: 8c3bdc1bc81e82f49acf03aaac5e8b65, type: 3}
       propertyPath: m_LocalPosition.z
@@ -8124,11 +8124,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 773176152485814612, guid: 8c3bdc1bc81e82f49acf03aaac5e8b65, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -6.72
+      value: -2.4
       objectReference: {fileID: 0}
     - target: {fileID: 773176152485814612, guid: 8c3bdc1bc81e82f49acf03aaac5e8b65, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 4.36
+      value: 3.54
       objectReference: {fileID: 0}
     - target: {fileID: 773176152485814612, guid: 8c3bdc1bc81e82f49acf03aaac5e8b65, type: 3}
       propertyPath: m_LocalPosition.z
@@ -8187,6 +8187,7 @@ GameObject:
   - component: {fileID: 305643271}
   - component: {fileID: 305643273}
   - component: {fileID: 305643272}
+  - component: {fileID: 305643274}
   m_Layer: 8
   m_Name: Ground_Hazard
   m_TagString: Untagged
@@ -8730,6 +8731,52 @@ Tilemap:
     e31: 0
     e32: 0
     e33: 1
+--- !u!19719996 &305643274
+TilemapCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 305643270}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  m_MaximumTileChangeCount: 1000
+  m_ExtrusionFactor: 0.00001
+--- !u!1 &411562180
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 411562181}
+  m_Layer: 0
+  m_Name: EndPosition
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &411562181
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 411562180}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 11.71, y: 8.66, z: -141.0809}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 13
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &425315489 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 2132301941, guid: 8c3bdc1bc81e82f49acf03aaac5e8b65, type: 3}
@@ -9616,6 +9663,66 @@ MonoBehaviour:
   _hazardLayer:
     serializedVersion: 2
     m_Bits: 256
+  _showGizmos: 0
+--- !u!1 &1370319799
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1370319801}
+  - component: {fileID: 1370319800}
+  - component: {fileID: 1370319802}
+  m_Layer: 0
+  m_Name: TestAStar
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1370319800
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1370319799}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 138400cc3049e4dd9a1e981c3ed6f778, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _start: {fileID: 1837318631}
+  _target: {fileID: 411562181}
+  _pathfinder: {fileID: 1370319802}
+--- !u!4 &1370319801
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1370319799}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 11
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1370319802
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1370319799}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 876349d7d9750419dbafe2511f0b9853, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &1374103583
 GameObject:
   m_ObjectHideFlags: 0
@@ -18178,6 +18285,36 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 06b1ecfa28b0ffd46ba3de65bcb76648, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!1 &1837318630
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1837318631}
+  m_Layer: 0
+  m_Name: StartPosition
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1837318631
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1837318630}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -12.05, y: -10.21, z: -141.0809}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 12
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1881693557
 GameObject:
   m_ObjectHideFlags: 0

--- a/UNITY/Assets/Scenes/Tilemaps.unity
+++ b/UNITY/Assets/Scenes/Tilemaps.unity
@@ -9613,6 +9613,9 @@ MonoBehaviour:
   _unwalkableLayer:
     serializedVersion: 2
     m_Bits: 1664
+  _hazardLayer:
+    serializedVersion: 2
+    m_Bits: 256
 --- !u!1 &1374103583
 GameObject:
   m_ObjectHideFlags: 0

--- a/UNITY/Assets/Scripts/AI/TankAI.cs
+++ b/UNITY/Assets/Scripts/AI/TankAI.cs
@@ -4,6 +4,15 @@ using WarOfTanks.Enums;
 
 namespace WarOfTanks.AI
 {
+    /// <summary>
+    /// Main AI controller for tank behavior. This class will manage the decision-making process for the tank, 
+    /// including pathfinding, target selection, and movement. It will utilize the PathfinderFactory to obtain
+    /// the appropriate pathfinding algorithm based on the current situation 
+    /// (e.g., A* for general navigation, Dijkstra for hazard avoidance, Flow Field for group movement). 
+    /// The TankAI will also handle interactions with the environment, such as detecting obstacles and hazards, and will update the tank's movement and actions accordingly.
+    /// The class will be designed to be modular and extensible, allowing for easy addition of new behaviors and decision-making logic as needed. 
+    /// It will also include error handling to ensure that the AI can gracefully handle situations where pathfinding fails or when the tank encounters unexpected obstacles.
+    /// </summary>
     public class TankAI : MonoBehaviour
     {
 

--- a/UNITY/Assets/Scripts/AI/TankAI.cs
+++ b/UNITY/Assets/Scripts/AI/TankAI.cs
@@ -1,0 +1,11 @@
+using UnityEngine;
+using WarOfTanks.Navigation;
+using WarOfTanks.Enums;
+
+namespace WarOfTanks.AI
+{
+    public class TankAI : MonoBehaviour
+    {
+
+    }
+}

--- a/UNITY/Assets/Scripts/AI/TankAI.cs.meta
+++ b/UNITY/Assets/Scripts/AI/TankAI.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 93e5f11e8e56f4df4a3d4b67e5eb749f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UNITY/Assets/Scripts/Enums/EPathfinderType.cs
+++ b/UNITY/Assets/Scripts/Enums/EPathfinderType.cs
@@ -1,0 +1,9 @@
+namespace WarOfTanks.Enums
+{
+    public enum EPathfinderType
+    {
+        ASTAR,
+        DIJKSTRA,
+        FLOWFIELD
+    }
+}

--- a/UNITY/Assets/Scripts/Enums/EPathfinderType.cs.meta
+++ b/UNITY/Assets/Scripts/Enums/EPathfinderType.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d1f5c7ebd9988433e9e8cd5160173b1f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UNITY/Assets/Scripts/Navigation/AStarPathfinder.cs
+++ b/UNITY/Assets/Scripts/Navigation/AStarPathfinder.cs
@@ -1,0 +1,99 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace WarOfTanks.Navigation
+{
+    public class AStarPathfinder : BasePathfinder
+    {
+        public override List<PathNode> FindPath(Vector2Int startPos, Vector2Int targetPos)
+        {
+            Grid grid = GetGrid();
+            if (grid == null)
+            {
+                return null;
+            }
+
+            PathNode startNode = grid.GetNode(startPos.x, startPos.y);
+            PathNode targetNode = grid.GetNode(targetPos.x, targetPos.y);
+            if (startNode == null || targetNode == null || !startNode.isWalkable || !targetNode.isWalkable)
+            {
+                return null;
+            }
+
+            List<PathNode> openSet = new List<PathNode>();
+            HashSet<PathNode> closedSet = new HashSet<PathNode>();
+
+            foreach (var node in grid.GetAllNodes())
+            {
+                node.ResetCosts();
+            }
+
+            startNode.gCost = 0f;
+            startNode.hCost = CalculateHeuristic(startNode, targetNode);
+
+            openSet.Add(startNode);
+
+            while (openSet.Count > 0)
+            {
+                PathNode currentNode = openSet[0];
+                for (int i = 1; i < openSet.Count; i++)
+                {
+                    if (openSet[i].fCost < currentNode.fCost || 
+                        (openSet[i].fCost == currentNode.fCost && openSet[i].hCost < currentNode.hCost))
+                    {
+                        currentNode = openSet[i];
+                    }
+                }
+
+                openSet.Remove(currentNode);
+                closedSet.Add(currentNode);
+
+                if (currentNode == targetNode)
+                {
+                    return RetracePath(startNode, targetNode);
+                }
+
+                foreach (PathNode neighbor in grid.GetNeighbors(currentNode))
+                {
+                    if (!neighbor.isWalkable || closedSet.Contains(neighbor))
+                    {
+                        continue;
+                    }
+
+                    float newMovementCostToNeighbor = currentNode.gCost + CalculateStepCost(currentNode, neighbor) + neighbor.movementCost;
+                    if (newMovementCostToNeighbor < neighbor.gCost || !openSet.Contains(neighbor))
+                    {
+                        neighbor.gCost = newMovementCostToNeighbor;
+                        neighbor.hCost = CalculateHeuristic(neighbor, targetNode);
+                        neighbor.parentNode = currentNode;
+
+                        if (!openSet.Contains(neighbor))
+                        {
+                            openSet.Add(neighbor);
+                        }
+                    }
+                }
+            }
+
+            return null; // No path found
+        }
+
+        private float CalculateStepCost(PathNode fromNode, PathNode toNode)
+        {
+            int xDistance = Mathf.Abs(fromNode.gridPosition.x - toNode.gridPosition.x);
+            int yDistance = Mathf.Abs(fromNode.gridPosition.y - toNode.gridPosition.y);
+
+            return xDistance == 1 && yDistance == 1 ? 1.4f : 1f;
+        }
+
+        private float CalculateHeuristic(PathNode a, PathNode b)
+        {
+            int xDistance = Mathf.Abs(a.gridPosition.x - b.gridPosition.x);
+            int yDistance = Mathf.Abs(a.gridPosition.y - b.gridPosition.y);
+            int diagonalMoves = Mathf.Min(xDistance, yDistance);
+            int straightMoves = Mathf.Abs(xDistance - yDistance);
+
+            return diagonalMoves * 1.4f + straightMoves;
+        }
+    }
+}

--- a/UNITY/Assets/Scripts/Navigation/AStarPathfinder.cs
+++ b/UNITY/Assets/Scripts/Navigation/AStarPathfinder.cs
@@ -3,22 +3,32 @@ using UnityEngine;
 
 namespace WarOfTanks.Navigation
 {
+    /// <summary>
+    /// A* pathfinding implementation. Finds the shortest weighted path between two grid positions,
+    /// accounting for terrain movement cost and diagonal movement (1.4x cost).
+    /// </summary>
     public class AStarPathfinder : BasePathfinder
     {
+        /// <summary>
+        /// Finds the optimal path from start to target using the A* algorithm.
+        /// The algorithm maintains an open set of nodes to explore and a closed set of nodes already evaluated.
+        /// It calculates GCost (actual cost from start to current node) and HCost (estimated cost from current node to target) for each node, using the octile distance heuristic for HCost.
+        /// The algorithm prioritizes nodes with the lowest FCost (GCost + HCost) and retraces the path from target to start once the target is reached.
+        /// If no path exists, it returns null. The method also handles edge cases such as invalid start/target positions and unwalkable nodes.
+        /// </summary>
+        /// <param name="startPos">Grid coordinates of the start cell.</param>
+        /// <param name="targetPos">Grid coordinates of the target cell.</param>
+        /// <returns>Ordered list of nodes forming the path, or null if no path exists.</returns>
         public override List<PathNode> FindPath(Vector2Int startPos, Vector2Int targetPos)
         {
             Grid grid = GetGrid();
             if (grid == null)
-            {
                 return null;
-            }
 
             PathNode startNode = grid.GetNode(startPos.x, startPos.y);
             PathNode targetNode = grid.GetNode(targetPos.x, targetPos.y);
             if (startNode == null || targetNode == null || !startNode.IsWalkable || !targetNode.IsWalkable)
-            {
                 return null;
-            }
 
             List<PathNode> openSet = new List<PathNode>();
             HashSet<PathNode> closedSet = new HashSet<PathNode>();
@@ -28,7 +38,6 @@ namespace WarOfTanks.Navigation
 
             startNode.GCost = 0f;
             startNode.HCost = CalculateHeuristic(startNode, targetNode);
-
             openSet.Add(startNode);
 
             while (openSet.Count > 0)
@@ -70,6 +79,14 @@ namespace WarOfTanks.Navigation
             return null;
         }
 
+        /// <summary>Returns 1.4 for diagonal moves, 1.0 for straight moves.
+        /// This accounts for the increased distance of diagonal movement on a grid.
+        /// Diagonal moves are more expensive than straight moves, which encourages more natural paths.
+        /// The base movement cost of the neighbor node is added to account for terrain difficulty (e.g., hazards).
+        /// </summary>
+        /// <param name="from">The node we are moving from.</param>
+        /// <param name="to">The node we are moving to.</param>
+        /// <returns>The total movement cost to move from the 'from' node to the 'to' node.</returns>
         private float CalculateStepCost(PathNode from, PathNode to)
         {
             int dx = Mathf.Abs(from.GridPosition.x - to.GridPosition.x);
@@ -77,6 +94,19 @@ namespace WarOfTanks.Navigation
             return dx == 1 && dy == 1 ? 1.4f : 1f;
         }
 
+        /// <summary>Octile distance heuristic — optimal for 8-direction grids.</summary>
+        /// Calculates the estimated cost to reach the target node from the current node, using the octile distance formula.
+        /// This heuristic is admissible and consistent for grids that allow diagonal movement, ensuring optimal paths.
+        /// The heuristic is calculated as follows:
+        /// - Calculate the absolute differences in x and y coordinates (dx and dy).
+        /// - Determine the number of diagonal steps possible (the smaller of dx and dy).
+        /// - Calculate the remaining straight steps after taking the diagonal steps.
+        /// - The total heuristic cost is the cost of the diagonal steps (diagonal * 1.4) plus the cost of the straight steps (straight * 1).
+        /// This heuristic effectively estimates the distance to the target while accounting for the possibility of diagonal movement, leading to more efficient pathfinding on grids that allow it.
+        /// </summary>
+        /// <param name="a">The node from which we are calculating the heuristic.</param>
+        /// <param name="b">The target node we are trying to reach.</param>
+        /// <returns>The estimated cost to reach the target node from the current node.</returns>
         private float CalculateHeuristic(PathNode a, PathNode b)
         {
             int dx = Mathf.Abs(a.GridPosition.x - b.GridPosition.x);

--- a/UNITY/Assets/Scripts/Navigation/AStarPathfinder.cs
+++ b/UNITY/Assets/Scripts/Navigation/AStarPathfinder.cs
@@ -15,7 +15,7 @@ namespace WarOfTanks.Navigation
 
             PathNode startNode = grid.GetNode(startPos.x, startPos.y);
             PathNode targetNode = grid.GetNode(targetPos.x, targetPos.y);
-            if (startNode == null || targetNode == null || !startNode.isWalkable || !targetNode.isWalkable)
+            if (startNode == null || targetNode == null || !startNode.IsWalkable || !targetNode.IsWalkable)
             {
                 return null;
             }
@@ -24,12 +24,10 @@ namespace WarOfTanks.Navigation
             HashSet<PathNode> closedSet = new HashSet<PathNode>();
 
             foreach (var node in grid.GetAllNodes())
-            {
                 node.ResetCosts();
-            }
 
-            startNode.gCost = 0f;
-            startNode.hCost = CalculateHeuristic(startNode, targetNode);
+            startNode.GCost = 0f;
+            startNode.HCost = CalculateHeuristic(startNode, targetNode);
 
             openSet.Add(startNode);
 
@@ -38,8 +36,8 @@ namespace WarOfTanks.Navigation
                 PathNode currentNode = openSet[0];
                 for (int i = 1; i < openSet.Count; i++)
                 {
-                    if (openSet[i].fCost < currentNode.fCost || 
-                        (openSet[i].fCost == currentNode.fCost && openSet[i].hCost < currentNode.hCost))
+                    if (openSet[i].FCost < currentNode.FCost ||
+                        (openSet[i].FCost == currentNode.FCost && openSet[i].HCost < currentNode.HCost))
                     {
                         currentNode = openSet[i];
                     }
@@ -49,51 +47,43 @@ namespace WarOfTanks.Navigation
                 closedSet.Add(currentNode);
 
                 if (currentNode == targetNode)
-                {
                     return RetracePath(startNode, targetNode);
-                }
 
                 foreach (PathNode neighbor in grid.GetNeighbors(currentNode))
                 {
-                    if (!neighbor.isWalkable || closedSet.Contains(neighbor))
-                    {
+                    if (!neighbor.IsWalkable || closedSet.Contains(neighbor))
                         continue;
-                    }
 
-                    float newMovementCostToNeighbor = currentNode.gCost + CalculateStepCost(currentNode, neighbor) + neighbor.movementCost;
-                    if (newMovementCostToNeighbor < neighbor.gCost || !openSet.Contains(neighbor))
+                    float newG = currentNode.GCost + CalculateStepCost(currentNode, neighbor) + neighbor.MovementCost;
+                    if (newG < neighbor.GCost || !openSet.Contains(neighbor))
                     {
-                        neighbor.gCost = newMovementCostToNeighbor;
-                        neighbor.hCost = CalculateHeuristic(neighbor, targetNode);
-                        neighbor.parentNode = currentNode;
+                        neighbor.GCost = newG;
+                        neighbor.HCost = CalculateHeuristic(neighbor, targetNode);
+                        neighbor.ParentNode = currentNode;
 
                         if (!openSet.Contains(neighbor))
-                        {
                             openSet.Add(neighbor);
-                        }
                     }
                 }
             }
 
-            return null; // No path found
+            return null;
         }
 
-        private float CalculateStepCost(PathNode fromNode, PathNode toNode)
+        private float CalculateStepCost(PathNode from, PathNode to)
         {
-            int xDistance = Mathf.Abs(fromNode.gridPosition.x - toNode.gridPosition.x);
-            int yDistance = Mathf.Abs(fromNode.gridPosition.y - toNode.gridPosition.y);
-
-            return xDistance == 1 && yDistance == 1 ? 1.4f : 1f;
+            int dx = Mathf.Abs(from.GridPosition.x - to.GridPosition.x);
+            int dy = Mathf.Abs(from.GridPosition.y - to.GridPosition.y);
+            return dx == 1 && dy == 1 ? 1.4f : 1f;
         }
 
         private float CalculateHeuristic(PathNode a, PathNode b)
         {
-            int xDistance = Mathf.Abs(a.gridPosition.x - b.gridPosition.x);
-            int yDistance = Mathf.Abs(a.gridPosition.y - b.gridPosition.y);
-            int diagonalMoves = Mathf.Min(xDistance, yDistance);
-            int straightMoves = Mathf.Abs(xDistance - yDistance);
-
-            return diagonalMoves * 1.4f + straightMoves;
+            int dx = Mathf.Abs(a.GridPosition.x - b.GridPosition.x);
+            int dy = Mathf.Abs(a.GridPosition.y - b.GridPosition.y);
+            int diagonal = Mathf.Min(dx, dy);
+            int straight = Mathf.Abs(dx - dy);
+            return diagonal * 1.4f + straight;
         }
     }
 }

--- a/UNITY/Assets/Scripts/Navigation/AStarPathfinder.cs.meta
+++ b/UNITY/Assets/Scripts/Navigation/AStarPathfinder.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 876349d7d9750419dbafe2511f0b9853
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UNITY/Assets/Scripts/Navigation/BasePathfinder.cs
+++ b/UNITY/Assets/Scripts/Navigation/BasePathfinder.cs
@@ -22,9 +22,7 @@ namespace WarOfTanks.Navigation
         protected List<PathNode> RetracePath(PathNode startNode, PathNode endNode)
         {
             if (startNode == null || endNode == null)
-            {
                 return null;
-            }
 
             var path = new List<PathNode>();
             var currentNode = endNode;
@@ -32,12 +30,10 @@ namespace WarOfTanks.Navigation
             while (currentNode != startNode)
             {
                 if (currentNode == null)
-                {
                     return null;
-                }
 
                 path.Add(currentNode);
-                currentNode = currentNode.parentNode;
+                currentNode = currentNode.ParentNode;
             }
 
             path.Reverse();

--- a/UNITY/Assets/Scripts/Navigation/BasePathfinder.cs
+++ b/UNITY/Assets/Scripts/Navigation/BasePathfinder.cs
@@ -3,6 +3,10 @@ using UnityEngine;
 
 namespace WarOfTanks.Navigation
 {
+    /// <summary>
+    /// Abstract base class for all pathfinding algorithms. Handles grid resolution and path retracing.
+    /// Subclasses implement the specific pathfinding logic in FindPath(). This design allows for easy swapping of algorithms without changing how the grid is accessed or how paths are retraced.
+    /// </summary>
     public abstract class BasePathfinder : MonoBehaviour, INavigable
     {
         private Grid _grid;
@@ -12,13 +16,35 @@ namespace WarOfTanks.Navigation
             _grid = FindObjectOfType<Grid>();
         }
 
+        /// <summary>Returns the navigation grid used by this pathfinder.</summary>
         public Grid GetGrid()
         {
             return _grid;
         }
 
+        /// <summary>
+        /// Finds a path between two grid positions. Implemented by each algorithm subclass.
+        /// The method should return an ordered list of PathNodes from the start position to the target position, or null if no path exists.
+        /// Implementations should handle edge cases such as invalid start/target positions and unwalkable nodes. 
+        /// The pathfinding logic will typically involve maintaining open and closed sets of nodes, calculating movement costs
+        /// and heuristics (for A*), and retracing the path once the target is reached. 
+        /// The specific details will depend on the algorithm being implemented (e.g., Dijkstra, A*, Flow Field).
+        /// </summary>
+        /// <param name="startPosition">Grid coordinates of the start cell.</param>
+        /// <param name="targetPosition">Grid coordinates of the target cell.</param>
+        /// <returns>Ordered list of nodes from start to target, or null if no path exists.</returns>
         public abstract List<PathNode> FindPath(Vector2Int startPosition, Vector2Int targetPosition);
 
+        /// <summary>
+        /// Reconstructs the path by walking back through each node's ParentNode from end to start.
+        /// The resulting path is reversed to provide an ordered list from start to target. 
+        /// This method is used by pathfinding algorithms like A* after reaching the target node.
+        /// The method also includes error handling to return null if retracing fails due to null nodes, 
+        /// which can occur in edge cases where the path cannot be properly constructed.
+        /// </summary>
+        /// <param name="startNode">The node where the path begins.</param>
+        /// <param name="endNode">The node where the path ends.</param>
+        /// <returns>Ordered list of nodes from start to target, or null if retracing fails.</returns>
         protected List<PathNode> RetracePath(PathNode startNode, PathNode endNode)
         {
             if (startNode == null || endNode == null)

--- a/UNITY/Assets/Scripts/Navigation/BasePathfinder.cs
+++ b/UNITY/Assets/Scripts/Navigation/BasePathfinder.cs
@@ -1,0 +1,47 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace WarOfTanks.Navigation
+{
+    public abstract class BasePathfinder : MonoBehaviour, INavigable
+    {
+        private Grid _grid;
+
+        protected virtual void Awake()
+        {
+            _grid = FindObjectOfType<Grid>();
+        }
+
+        public Grid GetGrid()
+        {
+            return _grid;
+        }
+
+        public abstract List<PathNode> FindPath(Vector2Int startPosition, Vector2Int targetPosition);
+
+        protected List<PathNode> RetracePath(PathNode startNode, PathNode endNode)
+        {
+            if (startNode == null || endNode == null)
+            {
+                return null;
+            }
+
+            var path = new List<PathNode>();
+            var currentNode = endNode;
+
+            while (currentNode != startNode)
+            {
+                if (currentNode == null)
+                {
+                    return null;
+                }
+
+                path.Add(currentNode);
+                currentNode = currentNode.parentNode;
+            }
+
+            path.Reverse();
+            return path;
+        }
+    }
+}

--- a/UNITY/Assets/Scripts/Navigation/BasePathfinder.cs.meta
+++ b/UNITY/Assets/Scripts/Navigation/BasePathfinder.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a6d4c5f1141e74957bd437ebe58646e2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UNITY/Assets/Scripts/Navigation/DijkstraPathfinder.cs
+++ b/UNITY/Assets/Scripts/Navigation/DijkstraPathfinder.cs
@@ -1,0 +1,14 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace WarOfTanks.Navigation
+{
+    public class DijkstraPathfinder : BasePathfinder
+    {
+        public override List<PathNode> FindPath(Vector2Int startPos, Vector2Int targetPos)
+        {
+            // Implement Dijkstra pathfinding logic here
+            return null;
+        }
+    }
+}

--- a/UNITY/Assets/Scripts/Navigation/DijkstraPathfinder.cs.meta
+++ b/UNITY/Assets/Scripts/Navigation/DijkstraPathfinder.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 473057a7db4ae4cdf922aa7098fdaf37
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UNITY/Assets/Scripts/Navigation/FlowFieldPathfinder.cs
+++ b/UNITY/Assets/Scripts/Navigation/FlowFieldPathfinder.cs
@@ -1,0 +1,14 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace WarOfTanks.Navigation
+{
+    public class FlowFieldPathfinder : BasePathfinder
+    {
+        public override List<PathNode> FindPath(Vector2Int startPos, Vector2Int targetPos)
+        {
+            // Implement flow field pathfinding logic here
+            return null;
+        }
+    }
+}

--- a/UNITY/Assets/Scripts/Navigation/FlowFieldPathfinder.cs.meta
+++ b/UNITY/Assets/Scripts/Navigation/FlowFieldPathfinder.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e826fa7c95f4b48419f7197322dd9eff
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UNITY/Assets/Scripts/Navigation/Grid.cs
+++ b/UNITY/Assets/Scripts/Navigation/Grid.cs
@@ -10,6 +10,7 @@ namespace WarOfTanks.Navigation
         [SerializeField] private float _cellSize;
         [SerializeField] private LayerMask _walkableLayer;
         [SerializeField] private LayerMask _unwalkableLayer;
+        [SerializeField] private LayerMask _hazardLayer;
         private PathNode[,] _nodes;
 
         private void Awake()
@@ -19,6 +20,11 @@ namespace WarOfTanks.Navigation
 
         public PathNode GetNode(int x, int y)
         {
+            if (!IsValidPosition(x, y))
+            {
+                return null;
+            }
+
             return _nodes[x, y];
         }
 
@@ -32,7 +38,10 @@ namespace WarOfTanks.Navigation
                 {
                     if (i == 0 && j == 0) continue;
 
-                    var neighborNode = GetNode(node.gridPosition.x + i, node.gridPosition.y + j);
+                    int neighborX = node.gridPosition.x + i;
+                    int neighborY = node.gridPosition.y + j;
+                    var neighborNode = GetNode(neighborX, neighborY);
+
                     if (neighborNode != null)
                     {
                         neighbors.Add(neighborNode);
@@ -45,8 +54,8 @@ namespace WarOfTanks.Navigation
         public Vector2Int WorldToGridPosition(Vector3 worldPosition)
         {
             Vector3 gridOrigin = transform.position - new Vector3(_width * _cellSize / 2f, _height * _cellSize / 2f, 0);
-            int x = Mathf.FloorToInt((worldPosition.x - gridOrigin.x) / _cellSize);
-            int y = Mathf.FloorToInt((worldPosition.y - gridOrigin.y) / _cellSize);
+            int x = Mathf.Clamp(Mathf.FloorToInt((worldPosition.x - gridOrigin.x) / _cellSize), 0, _width - 1);
+            int y = Mathf.Clamp(Mathf.FloorToInt((worldPosition.y - gridOrigin.y) / _cellSize), 0, _height - 1);
             return new Vector2Int(x, y);
         }
 
@@ -69,9 +78,18 @@ namespace WarOfTanks.Navigation
                     Vector3 worldPosition = GridToWorldPosition(new Vector2Int(x, y));
                     bool isWalkable = Physics2D.OverlapCircle(worldPosition, _cellSize * 0.1f, _walkableLayer)
                                    && !Physics2D.OverlapCircle(worldPosition, _cellSize * 0.1f, _unwalkableLayer);
-                    _nodes[x, y] = new PathNode(new Vector2Int(x, y), isWalkable);
+
+                    bool isHazard = Physics2D.OverlapCircle(worldPosition, _cellSize * 0.1f, _hazardLayer);
+                    var node = new PathNode(new Vector2Int(x, y), isWalkable);
+                    node.movementCost = isHazard ? 3f : 1f;
+                    _nodes[x, y] = node;
                 }
             }
+        }
+
+        public bool IsValidPosition(int x, int y)
+        {
+            return x >= 0 && x < _width && y >= 0 && y < _height;
         }
 
         private void OnDrawGizmos()

--- a/UNITY/Assets/Scripts/Navigation/Grid.cs
+++ b/UNITY/Assets/Scripts/Navigation/Grid.cs
@@ -11,6 +11,7 @@ namespace WarOfTanks.Navigation
         [SerializeField] private LayerMask _walkableLayer;
         [SerializeField] private LayerMask _unwalkableLayer;
         [SerializeField] private LayerMask _hazardLayer;
+        [SerializeField] private bool _showGizmos;
         private PathNode[,] _nodes;
 
         private void Awake()
@@ -81,6 +82,7 @@ namespace WarOfTanks.Navigation
 
                     bool isHazard = Physics2D.OverlapCircle(worldPosition, _cellSize * 0.1f, _hazardLayer);
                     var node = new PathNode(new Vector2Int(x, y), isWalkable);
+                    node.isHazard = isHazard;
                     node.movementCost = isHazard ? 3f : 1f;
                     _nodes[x, y] = node;
                 }
@@ -92,17 +94,24 @@ namespace WarOfTanks.Navigation
             return x >= 0 && x < _width && y >= 0 && y < _height;
         }
 
+        public IEnumerable<PathNode> GetAllNodes()
+        {
+            for (int x = 0; x < _width; x++)
+                for (int y = 0; y < _height; y++)
+                    yield return _nodes[x, y];
+        }
+
         private void OnDrawGizmos()
         {
         #if UNITY_EDITOR
-            if (_nodes == null) return;
+            if (_nodes == null || !_showGizmos) return;
 
             for (int x = 0; x < _width; x++)
             {
                 for (int y = 0; y < _height; y++)
                 {
                     var node = _nodes[x, y];
-                    Gizmos.color = node.isWalkable ? Color.green : Color.red;
+                    Gizmos.color = !node.isWalkable ? Color.red : node.isHazard ? Color.yellow : Color.green;
                     Vector3 worldPosition = GridToWorldPosition(node.gridPosition);
                     Gizmos.DrawCube(worldPosition, Vector3.one * (_cellSize - 0.1f));
                 }

--- a/UNITY/Assets/Scripts/Navigation/Grid.cs
+++ b/UNITY/Assets/Scripts/Navigation/Grid.cs
@@ -1,0 +1,95 @@
+using UnityEngine;
+using System.Collections.Generic;
+
+namespace WarOfTanks.Navigation
+{
+    public class Grid : MonoBehaviour
+    {
+        [SerializeField] private int _width;
+        [SerializeField] private int _height;
+        [SerializeField] private float _cellSize;
+        [SerializeField] private LayerMask _walkableLayer;
+        [SerializeField] private LayerMask _unwalkableLayer;
+        private PathNode[,] _nodes;
+
+        private void Awake()
+        {
+           InitializeGrid();
+        }
+
+        public PathNode GetNode(int x, int y)
+        {
+            return _nodes[x, y];
+        }
+
+        public List<PathNode> GetNeighbors(PathNode node)
+        {
+            var neighbors = new List<PathNode>();
+
+            for (int i = -1; i <= 1; i++)
+            {
+                for (int j = -1; j <= 1; j++)
+                {
+                    if (i == 0 && j == 0) continue;
+
+                    var neighborNode = GetNode(node.gridPosition.x + i, node.gridPosition.y + j);
+                    if (neighborNode != null)
+                    {
+                        neighbors.Add(neighborNode);
+                    }
+                }
+            }
+            return neighbors;
+        }
+
+        public Vector2Int WorldToGridPosition(Vector3 worldPosition)
+        {
+            Vector3 gridOrigin = transform.position - new Vector3(_width * _cellSize / 2f, _height * _cellSize / 2f, 0);
+            int x = Mathf.FloorToInt((worldPosition.x - gridOrigin.x) / _cellSize);
+            int y = Mathf.FloorToInt((worldPosition.y - gridOrigin.y) / _cellSize);
+            return new Vector2Int(x, y);
+        }
+
+        public Vector3 GridToWorldPosition(Vector2Int gridPosition)
+        {
+            Vector3 gridOrigin = transform.position - new Vector3(_width * _cellSize / 2f, _height * _cellSize / 2f, 0);
+            float x = gridPosition.x * _cellSize + _cellSize / 2f;
+            float y = gridPosition.y * _cellSize + _cellSize / 2f;
+            return gridOrigin + new Vector3(x, y, 0);
+        }
+
+        public void InitializeGrid()
+        {
+            _nodes = new PathNode[_width, _height];
+
+            for (int x = 0; x < _width; x++)
+            {
+                for (int y = 0; y < _height; y++)
+                {
+                    Vector3 worldPosition = GridToWorldPosition(new Vector2Int(x, y));
+                    bool isWalkable = Physics2D.OverlapCircle(worldPosition, _cellSize * 0.1f, _walkableLayer)
+                                   && !Physics2D.OverlapCircle(worldPosition, _cellSize * 0.1f, _unwalkableLayer);
+                    _nodes[x, y] = new PathNode(new Vector2Int(x, y), isWalkable);
+                }
+            }
+        }
+
+        private void OnDrawGizmos()
+        {
+        #if UNITY_EDITOR
+            if (_nodes == null) return;
+
+            for (int x = 0; x < _width; x++)
+            {
+                for (int y = 0; y < _height; y++)
+                {
+                    var node = _nodes[x, y];
+                    Gizmos.color = node.isWalkable ? Color.green : Color.red;
+                    Vector3 worldPosition = GridToWorldPosition(node.gridPosition);
+                    Gizmos.DrawCube(worldPosition, Vector3.one * (_cellSize - 0.1f));
+                }
+            }
+        #endif
+        }
+    }
+}

--- a/UNITY/Assets/Scripts/Navigation/Grid.cs
+++ b/UNITY/Assets/Scripts/Navigation/Grid.cs
@@ -39,14 +39,11 @@ namespace WarOfTanks.Navigation
                 {
                     if (i == 0 && j == 0) continue;
 
-                    int neighborX = node.gridPosition.x + i;
-                    int neighborY = node.gridPosition.y + j;
+                    int neighborX = node.GridPosition.x + i;
+                    int neighborY = node.GridPosition.y + j;
                     var neighborNode = GetNode(neighborX, neighborY);
-
                     if (neighborNode != null)
-                    {
                         neighbors.Add(neighborNode);
-                    }
                 }
             }
             return neighbors;
@@ -82,8 +79,8 @@ namespace WarOfTanks.Navigation
 
                     bool isHazard = Physics2D.OverlapCircle(worldPosition, _cellSize * 0.1f, _hazardLayer);
                     var node = new PathNode(new Vector2Int(x, y), isWalkable);
-                    node.isHazard = isHazard;
-                    node.movementCost = isHazard ? 3f : 1f;
+                    node.IsHazard = isHazard;
+                    node.MovementCost = isHazard ? 3f : 1f;
                     _nodes[x, y] = node;
                 }
             }
@@ -111,8 +108,8 @@ namespace WarOfTanks.Navigation
                 for (int y = 0; y < _height; y++)
                 {
                     var node = _nodes[x, y];
-                    Gizmos.color = !node.isWalkable ? Color.red : node.isHazard ? Color.yellow : Color.green;
-                    Vector3 worldPosition = GridToWorldPosition(node.gridPosition);
+                    Gizmos.color = !node.IsWalkable ? Color.red : node.IsHazard ? Color.yellow : Color.green;
+                    Vector3 worldPosition = GridToWorldPosition(node.GridPosition);
                     Gizmos.DrawCube(worldPosition, Vector3.one * (_cellSize - 0.1f));
                 }
             }

--- a/UNITY/Assets/Scripts/Navigation/Grid.cs
+++ b/UNITY/Assets/Scripts/Navigation/Grid.cs
@@ -3,6 +3,10 @@ using System.Collections.Generic;
 
 namespace WarOfTanks.Navigation
 {
+    /// <summary>
+    /// Builds and owns the navigation grid. Samples Physics2D layers on Awake to determine
+    /// walkability and hazard status for each cell.
+    /// </summary>
     public class Grid : MonoBehaviour
     {
         [SerializeField] private int _width;
@@ -16,19 +20,34 @@ namespace WarOfTanks.Navigation
 
         private void Awake()
         {
-           InitializeGrid();
+            InitializeGrid();
         }
 
+        /// <summary>
+        /// Returns the node at the given grid coordinates, or null if out of bounds.
+        /// This method is used by pathfinding algorithms to access node data such as walkability and movement cost.
+        /// The method includes bounds checking to prevent errors from invalid coordinates. 
+        /// Pathfinding algorithms will typically call this method frequently, so it is optimized for fast access to node data.
+        /// <param name="x">X coordinate of the grid cell.</param>
+        /// <param name="y">Y coordinate of the grid cell.</param>
+        /// <returns>The PathNode at the specified coordinates, or null if out of bounds.</returns>
+        /// </summary>
         public PathNode GetNode(int x, int y)
         {
             if (!IsValidPosition(x, y))
-            {
                 return null;
-            }
 
             return _nodes[x, y];
         }
 
+        /// <summary>
+        /// Returns all 8-directional neighbors of the given node that are within grid bounds.
+        /// This method is used by pathfinding algorithms to explore adjacent nodes when calculating paths.
+        /// The method checks all 8 surrounding positions (including diagonals) and returns valid neighbors that are within the grid bounds. 
+        /// Pathfinding algorithms will typically call this method for each node they evaluate, so it is optimized for fast retrieval of neighboring nodes.
+        /// <param name="node">The node for which to find neighbors.</param>
+        /// <returns>A list of neighboring PathNodes that are within grid bounds.</returns>
+        /// </summary>
         public List<PathNode> GetNeighbors(PathNode node)
         {
             var neighbors = new List<PathNode>();
@@ -49,6 +68,15 @@ namespace WarOfTanks.Navigation
             return neighbors;
         }
 
+        /// <summary>
+        /// Converts a world position to the nearest grid coordinates.
+        /// This method is used to translate between the game's world space and the grid-based navigation system.
+        /// It calculates the grid coordinates by determining the offset from the grid's origin and dividing by
+        /// the cell size. The resulting coordinates are clamped to ensure they fall within the grid bounds.
+        /// Pathfinding algorithms and AI will typically call this method when they need to convert a target position in the world to grid coordinates for pathfinding purposes.
+        /// <param name="worldPosition">The world position to convert.</param>
+        /// <returns>The corresponding grid coordinates as a Vector2Int, clamped to the grid bounds.</returns>
+        /// </summary>
         public Vector2Int WorldToGridPosition(Vector3 worldPosition)
         {
             Vector3 gridOrigin = transform.position - new Vector3(_width * _cellSize / 2f, _height * _cellSize / 2f, 0);
@@ -57,6 +85,11 @@ namespace WarOfTanks.Navigation
             return new Vector2Int(x, y);
         }
 
+        /// <summary>
+        /// Converts grid coordinates to the world position at the center of that cell.
+        /// </summary>
+        /// <param name="gridPosition">The grid coordinates to convert.</param>
+        /// <returns>The corresponding world position.</returns>
         public Vector3 GridToWorldPosition(Vector2Int gridPosition)
         {
             Vector3 gridOrigin = transform.position - new Vector3(_width * _cellSize / 2f, _height * _cellSize / 2f, 0);
@@ -65,6 +98,13 @@ namespace WarOfTanks.Navigation
             return gridOrigin + new Vector3(x, y, 0);
         }
 
+        /// <summary>
+        /// Populates the node array by sampling Physics2D layers at each cell's world position.
+        /// The method iterates over the grid dimensions and calculates the world position for each cell. 
+        /// It uses Physics2D.OverlapCircle to check for colliders on the walkable, unwalkable, and hazard layers to determine the properties of each node.
+        /// Walkable nodes are those that have a collider on the walkable layer and no collider on the unwalkable layer. 
+        /// Hazard nodes are those that have a collider on the hazard layer.
+        /// </summary>
         public void InitializeGrid()
         {
             _nodes = new PathNode[_width, _height];
@@ -86,11 +126,19 @@ namespace WarOfTanks.Navigation
             }
         }
 
+        /// <summary>Returns true if the given grid coordinates are within bounds.</summary>
+        /// This method is used to validate grid coordinates before accessing nodes. 
+        /// It checks that the x and y coordinates are non-negative and less than the grid's width and height, respectively.
+        /// Pathfinding algorithms will typically call this method before attempting to access a node at specific coordinates to prevent out-of-bounds errors.
+        /// <param name="x">X coordinate of the grid cell.</param>
+        /// <param name="y">Y coordinate of the grid cell.</param>
+        /// <returns>True if the coordinates are within the grid bounds, false otherwise.</returns>
         public bool IsValidPosition(int x, int y)
         {
             return x >= 0 && x < _width && y >= 0 && y < _height;
         }
 
+        /// <summary>Iterates over all nodes in the grid.</summary>
         public IEnumerable<PathNode> GetAllNodes()
         {
             for (int x = 0; x < _width; x++)

--- a/UNITY/Assets/Scripts/Navigation/Grid.cs.meta
+++ b/UNITY/Assets/Scripts/Navigation/Grid.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 986cf6282ca4d4c32b11ab8a1b728f98
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UNITY/Assets/Scripts/Navigation/INavigable.cs
+++ b/UNITY/Assets/Scripts/Navigation/INavigable.cs
@@ -3,10 +3,21 @@ using UnityEngine;
 
 namespace WarOfTanks.Navigation
 {
+    /// <summary>
+    /// Contract for all pathfinding algorithms. Allows TankAI and PathfinderFactory
+    /// to remain decoupled from specific implementations (A*, Dijkstra, FlowField).
+    /// </summary>
     public interface INavigable
     {
-        public List<PathNode> FindPath(Vector2Int startPosition, Vector2Int targetPosition);
+        /// <summary>
+        /// Finds a path between two grid positions.
+        /// </summary>
+        /// <param name="startPosition">Grid coordinates of the start cell.</param>
+        /// <param name="targetPosition">Grid coordinates of the target cell.</param>
+        /// <returns>Ordered list of nodes from start to target, or null if no path exists.</returns>
+        List<PathNode> FindPath(Vector2Int startPosition, Vector2Int targetPosition);
 
-        public Grid GetGrid();
+        /// <summary>Returns the navigation grid used by this pathfinder.</summary>
+        Grid GetGrid();
     }
 }

--- a/UNITY/Assets/Scripts/Navigation/INavigable.cs
+++ b/UNITY/Assets/Scripts/Navigation/INavigable.cs
@@ -1,0 +1,12 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace WarOfTanks.Navigation
+{
+    public interface INavigable
+    {
+        public List<PathNode> FindPath(Vector2Int startPosition, Vector2Int targetPosition);
+
+        public Grid GetGrid();
+    }
+}

--- a/UNITY/Assets/Scripts/Navigation/INavigable.cs.meta
+++ b/UNITY/Assets/Scripts/Navigation/INavigable.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ac8ccc9d97b9c4e6193b42dbebcefe82
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UNITY/Assets/Scripts/Navigation/PathNode.cs
+++ b/UNITY/Assets/Scripts/Navigation/PathNode.cs
@@ -4,28 +4,36 @@ namespace WarOfTanks.Navigation
 {
     public class PathNode
     {
-        public Vector2Int gridPosition;
-        public bool isWalkable;
-        public bool isHazard;
-        public float movementCost;
-        public float gCost;
-        public float hCost;
-        public float fCost => gCost + hCost;
-        public PathNode parentNode;
+        private Vector2Int _gridPosition;
+        private bool _isWalkable;
+        private bool _isHazard;
+        private float _movementCost;
+        private float _gCost;
+        private float _hCost;
+        private PathNode _parentNode;
+
+        public Vector2Int GridPosition => _gridPosition;
+        public bool IsWalkable => _isWalkable;
+        public bool IsHazard { get => _isHazard; set => _isHazard = value; }
+        public float MovementCost { get => _movementCost; set => _movementCost = value; }
+        public float GCost { get => _gCost; set => _gCost = value; }
+        public float HCost { get => _hCost; set => _hCost = value; }
+        public float FCost => _gCost + _hCost;
+        public PathNode ParentNode { get => _parentNode; set => _parentNode = value; }
 
         public PathNode(Vector2Int gridPosition, bool isWalkable)
         {
-            this.gridPosition = gridPosition;
-            this.isWalkable = isWalkable;
-            movementCost = 1f;
+            _gridPosition = gridPosition;
+            _isWalkable = isWalkable;
+            _movementCost = 1f;
             ResetCosts();
         }
 
         public void ResetCosts()
         {
-            gCost = float.PositiveInfinity;
-            hCost = 0f;
-            parentNode = null;
+            _gCost = float.PositiveInfinity;
+            _hCost = 0f;
+            _parentNode = null;
         }
     }
 }

--- a/UNITY/Assets/Scripts/Navigation/PathNode.cs
+++ b/UNITY/Assets/Scripts/Navigation/PathNode.cs
@@ -6,6 +6,7 @@ namespace WarOfTanks.Navigation
     {
         public Vector2Int gridPosition;
         public bool isWalkable;
+        public bool isHazard;
         public float movementCost;
         public float gCost;
         public float hCost;

--- a/UNITY/Assets/Scripts/Navigation/PathNode.cs
+++ b/UNITY/Assets/Scripts/Navigation/PathNode.cs
@@ -2,6 +2,9 @@ using UnityEngine;
 
 namespace WarOfTanks.Navigation
 {
+    /// <summary>
+    /// Represents a single cell in the navigation grid used by pathfinding algorithms.
+    /// </summary>
     public class PathNode
     {
         private Vector2Int _gridPosition;
@@ -12,15 +15,32 @@ namespace WarOfTanks.Navigation
         private float _hCost;
         private PathNode _parentNode;
 
+        /// <summary>Grid coordinates of this node.</summary>
         public Vector2Int GridPosition => _gridPosition;
+
+        /// <summary>Whether tanks can traverse this node.</summary>
         public bool IsWalkable => _isWalkable;
+
+        /// <summary>Whether this node is a hazard tile (higher movement cost, reduces tank speed).</summary>
         public bool IsHazard { get => _isHazard; set => _isHazard = value; }
+
+        /// <summary>Terrain cost multiplier applied when entering this node.</summary>
         public float MovementCost { get => _movementCost; set => _movementCost = value; }
+
+        /// <summary>Accumulated cost from the start node to this node.</summary>
         public float GCost { get => _gCost; set => _gCost = value; }
+
+        /// <summary>Estimated cost from this node to the target node (heuristic).</summary>
         public float HCost { get => _hCost; set => _hCost = value; }
+
+        /// <summary>Total estimated path cost (GCost + HCost).</summary>
         public float FCost => _gCost + _hCost;
+
+        /// <summary>Previous node in the path, used to retrace the path once the target is reached.</summary>
         public PathNode ParentNode { get => _parentNode; set => _parentNode = value; }
 
+        /// <param name="gridPosition">Grid coordinates of this node.</param>
+        /// <param name="isWalkable">Whether tanks can traverse this node.</param>
         public PathNode(Vector2Int gridPosition, bool isWalkable)
         {
             _gridPosition = gridPosition;
@@ -29,6 +49,9 @@ namespace WarOfTanks.Navigation
             ResetCosts();
         }
 
+        /// <summary>
+        /// Resets pathfinding costs before each new search to avoid stale data from previous calls.
+        /// </summary>
         public void ResetCosts()
         {
             _gCost = float.PositiveInfinity;

--- a/UNITY/Assets/Scripts/Navigation/PathNode.cs
+++ b/UNITY/Assets/Scripts/Navigation/PathNode.cs
@@ -1,0 +1,27 @@
+using UnityEngine;
+
+namespace WarOfTanks.Navigation
+{
+    public class PathNode
+    {
+        public Vector2Int gridPosition;
+        public bool isWalkable;
+        public float movementCost;
+        public float gCost;
+        public float hCost;
+        public float fCost => gCost + hCost;
+        public PathNode parentNode;
+
+        public PathNode(Vector2Int gridPosition, bool isWalkable)
+        {
+            this.gridPosition = gridPosition;
+            this.isWalkable = isWalkable;
+        }
+
+        public void ResetCosts()
+        {
+            gCost = 0;
+            hCost = 0;
+        }
+    }
+}

--- a/UNITY/Assets/Scripts/Navigation/PathNode.cs
+++ b/UNITY/Assets/Scripts/Navigation/PathNode.cs
@@ -16,12 +16,15 @@ namespace WarOfTanks.Navigation
         {
             this.gridPosition = gridPosition;
             this.isWalkable = isWalkable;
+            movementCost = 1f;
+            ResetCosts();
         }
 
         public void ResetCosts()
         {
-            gCost = 0;
-            hCost = 0;
+            gCost = float.PositiveInfinity;
+            hCost = 0f;
+            parentNode = null;
         }
     }
 }

--- a/UNITY/Assets/Scripts/Navigation/PathNode.cs.meta
+++ b/UNITY/Assets/Scripts/Navigation/PathNode.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 60370448a159841c69f2f7b4936aec1d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UNITY/Assets/Scripts/Navigation/PathfinderFactory.cs
+++ b/UNITY/Assets/Scripts/Navigation/PathfinderFactory.cs
@@ -2,6 +2,15 @@ using WarOfTanks.Enums;
 
 namespace WarOfTanks.Navigation
 {
+    /// <summary>
+    /// Factory class for creating pathfinder instances based on the specified algorithm type.
+    /// This class provides a centralized method to instantiate different pathfinding algorithms 
+    /// (e.g., A*, Dijkstra, Flow Field) without exposing the details of their construction to the rest of the codebase. 
+    /// The factory method takes an enum value representing the desired algorithm and returns an 
+    /// instance of the corresponding pathfinder class. 
+    /// This design allows for easy swapping of pathfinding algorithms by simply changing the enum value, 
+    /// without needing to modify the code that uses the pathfinder instances.
+    /// </summary>
     public static class PathfinderFactory
     {
 

--- a/UNITY/Assets/Scripts/Navigation/PathfinderFactory.cs
+++ b/UNITY/Assets/Scripts/Navigation/PathfinderFactory.cs
@@ -1,0 +1,9 @@
+using WarOfTanks.Enums;
+
+namespace WarOfTanks.Navigation
+{
+    public static class PathfinderFactory
+    {
+
+    }
+}

--- a/UNITY/Assets/Scripts/Navigation/PathfinderFactory.cs.meta
+++ b/UNITY/Assets/Scripts/Navigation/PathfinderFactory.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: cdd8ee6717ed7488fb7d17450c28ed14
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UNITY/Assets/Scripts/Testing/AStarTest.cs
+++ b/UNITY/Assets/Scripts/Testing/AStarTest.cs
@@ -41,7 +41,7 @@ public class AStarTest : MonoBehaviour
         Gizmos.color = Color.yellow;
         foreach (var node in _path)
         {
-            Vector3 worldPos = _pathfinder.GetGrid().GridToWorldPosition(node.gridPosition);
+            Vector3 worldPos = _pathfinder.GetGrid().GridToWorldPosition(node.GridPosition);
             Gizmos.DrawCube(worldPos, Vector3.one * 0.5f);
         }
     }

--- a/UNITY/Assets/Scripts/Testing/AStarTest.cs
+++ b/UNITY/Assets/Scripts/Testing/AStarTest.cs
@@ -2,6 +2,14 @@ using System.Collections.Generic;
 using UnityEngine;
 using WarOfTanks.Navigation;
 
+/// <summary>
+/// Test script to visualize A* pathfinding in the Unity editor. Allows setting start and target
+/// positions via Transforms and draws the resulting path using Gizmos. The script retrieves the grid from the AStarPathfinder instance
+/// and converts world positions to grid coordinates for pathfinding. It also includes error handling to ensure that the path is only drawn when valid data is available.
+/// This script is intended for testing and debugging the A* pathfinding implementation by providing a visual
+/// representation of the calculated path in the Unity editor. It can be attached to any GameObject, and the start and target Transforms can be assigned via the inspector.
+/// The path will be drawn as yellow cubes at the center of each grid cell along the calculated path from the start to the target position.
+/// </summary>
 public class AStarTest : MonoBehaviour
 {
     [SerializeField] private Transform _start;

--- a/UNITY/Assets/Scripts/Testing/AStarTest.cs
+++ b/UNITY/Assets/Scripts/Testing/AStarTest.cs
@@ -1,0 +1,48 @@
+using System.Collections.Generic;
+using UnityEngine;
+using WarOfTanks.Navigation;
+
+public class AStarTest : MonoBehaviour
+{
+    [SerializeField] private Transform _start;
+    [SerializeField] private Transform _target;
+    [SerializeField] private AStarPathfinder _pathfinder;
+
+    private List<PathNode> _path;
+
+    private void Awake()
+    {
+        if (_pathfinder == null)
+        {
+            _pathfinder = FindObjectOfType<AStarPathfinder>();
+        }
+    }
+
+    private void Update()
+    {
+        if (_pathfinder == null || _start == null || _target == null || _pathfinder.GetGrid() == null)
+        {
+            return;
+        }
+
+        Vector2Int startGrid = _pathfinder.GetGrid().WorldToGridPosition(_start.position);
+        Vector2Int targetGrid = _pathfinder.GetGrid().WorldToGridPosition(_target.position);
+
+        _path = _pathfinder.FindPath(startGrid, targetGrid);
+    }
+
+    private void OnDrawGizmos()
+    {
+        if (_path == null || _pathfinder == null || _pathfinder.GetGrid() == null)
+        {
+            return;
+        }
+
+        Gizmos.color = Color.yellow;
+        foreach (var node in _path)
+        {
+            Vector3 worldPos = _pathfinder.GetGrid().GridToWorldPosition(node.gridPosition);
+            Gizmos.DrawCube(worldPos, Vector3.one * 0.5f);
+        }
+    }
+}

--- a/UNITY/Assets/Scripts/Testing/AStarTest.cs.meta
+++ b/UNITY/Assets/Scripts/Testing/AStarTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 138400cc3049e4dd9a1e981c3ed6f778
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Summary
- Implemented A* pathfinding algorithm from scratch using a custom Grid and PathNode system
- Built a LayerMask-based grid that samples Physics2D colliders to determine walkability and hazard status per cell
- Added diagonal movement support with correct 1.4x step cost and octile distance heuristic
- Hazard tiles have a configurable movement cost multiplier (default 3x) so A* naturally avoids them
- Full XML documentation on all public APIs across the navigation system

## Issue
Closes #13

## Changes
- `Navigation/PathNode.cs` — data class with private backing fields, public properties, and ResetCosts() for clean multi-call support
- `Navigation/Grid.cs` — MonoBehaviour that builds a PathNode[,] array via Physics2D layer sampling; exposes GetNode, GetNeighbors, WorldToGridPosition, GridToWorldPosition, GetAllNodes; toggleable Gizmo visualization
- `Navigation/INavigable.cs` — interface contract decoupling TankAI and PathfinderFactory from specific algorithm implementations
- `Navigation/BasePathfinder.cs` — abstract MonoBehaviour implementing INavigable; shared grid resolution and RetracePath logic
- `Navigation/AStarPathfinder.cs` — full A* implementation with open/closed sets, octile heuristic, hazard cost integration, and null-safe path retracing
- `Navigation/PathfinderFactory.cs` — static factory stub (scaffolded for future issues)
- `Navigation/DijkstraPathfinder.cs` — stub (scaffolded for future issues)
- `Navigation/FlowFieldPathfinder.cs` — stub (scaffolded for future issues)
- `Enums/EPathfinderType.cs` — enum for algorithm selection (ASTAR, DIJKSTRA, FLOWFIELD)
- `AI/TankAI.cs` — stub with namespace and imports (scaffolded for future issues)
- `Testing/AStarTest.cs` — editor test script with live path recalculation and yellow Gizmo path visualization

## Definition of Done
- [x] `PathNode` class created with all required fields
- [x] `Grid` MonoBehaviour builds the navigation grid from layer data on Awake
- [x] `Grid` correctly marks tiles as walkable/unwalkable using Physics2D LayerMask sampling
- [x] `AStarPathfinder` implements `INavigable`
- [x] `FindPath()` returns a valid path between two walkable points
- [x] Path correctly avoids Unwalkable tiles
- [x] Hazard tiles have higher movement cost (3x default, configurable)
- [ ] Tanks visually follow the computed path in Play mode — deferred to TankAI issue
- [x] `FindPath()` returns null gracefully when no path exists
- [x] Diagonal movement supported with correct cost (1.4x)
- [x] Debug Gizmos: grid and path drawn in Scene view (Editor only, `#if UNITY_EDITOR`)
- [x] SOLID check passed — INavigable enforces Dependency Inversion
- [ ] Performance: full-size map stress test — to be validated in integration testing

## Pre-PR Checks
- [x] SOLID principles: ✅ Pass — DIP enforced via INavigable, SRP respected per class
- [x] Naming conventions: ✅ Pass — PascalCase properties, _camelCase private fields, I-prefix interface
- [x] Documentation: ✅ Pass — XML docs on all public methods and properties

## Notes
- Grid uses Physics2D LayerMask instead of Tilemap references — more flexible and works with existing collider-based layers
- `PathfinderFactory`, `DijkstraPathfinder`, `FlowFieldPathfinder`, and `TankAI` are intentional stubs for upcoming issues (#14, #15, #16)
- "Tanks follow the path" DoD item is deferred — TankAI movement integration is tracked separately