### PR TITLE
[#51] Frontend App Structure — Routing, Axios Client, Types, Pages

### DIFF
--- a/FRONTEND/.env.example
+++ b/FRONTEND/.env.example
@@ -1,0 +1,1 @@
+VITE_API_URL=http://localhost:8080

--- a/FRONTEND/.gitignore
+++ b/FRONTEND/.gitignore
@@ -22,3 +22,5 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+.env

--- a/FRONTEND/package-lock.json
+++ b/FRONTEND/package-lock.json
@@ -9,8 +9,10 @@
       "version": "0.0.0",
       "dependencies": {
         "@tailwindcss/vite": "^4.2.2",
+        "axios": "^1.15.2",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
+        "react-router-dom": "^7.14.2",
         "tailwindcss": "^4.2.2"
       },
       "devDependencies": {
@@ -1526,6 +1528,23 @@
       "dev": true,
       "license": "Python-2.0"
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
+    "node_modules/axios": {
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.2.tgz",
+      "integrity": "sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.11",
+        "form-data": "^4.0.5",
+        "proxy-from-env": "^2.1.0"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -1589,6 +1608,19 @@
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/callsites": {
@@ -1659,6 +1691,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -1672,6 +1716,19 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -1720,6 +1777,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -1727,6 +1793,20 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/electron-to-chromium": {
@@ -1747,6 +1827,51 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/escalade": {
@@ -2045,6 +2170,42 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/follow-redirects": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -2059,6 +2220,15 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -2067,6 +2237,43 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/glob-parent": {
@@ -2095,6 +2302,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
@@ -2109,6 +2328,45 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/hermes-estree": {
@@ -2586,6 +2844,36 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/minimatch": {
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
@@ -2880,6 +3168,15 @@
         }
       }
     },
+    "node_modules/proxy-from-env": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -2909,6 +3206,44 @@
       },
       "peerDependencies": {
         "react": "^19.2.5"
+      }
+    },
+    "node_modules/react-router": {
+      "version": "7.14.2",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.14.2.tgz",
+      "integrity": "sha512-yCqNne6I8IB6rVCH7XUvlBK7/QKyqypBFGv+8dj4QBFJiiRX+FG7/nkdAvGElyvVZ/HQP5N19wzteuTARXi5Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.14.2",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.14.2.tgz",
+      "integrity": "sha512-YZcM5ES8jJSM+KrJ9BdvHHqlnGTg5tH3sC5ChFRj4inosKctdyzBDhOyyHdGk597q2OT6NTrCA1OvB/YDwfekQ==",
+      "license": "MIT",
+      "dependencies": {
+        "react-router": "7.14.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
       }
     },
     "node_modules/resolve-from": {
@@ -2975,6 +3310,12 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
+      "license": "MIT"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",

--- a/FRONTEND/package.json
+++ b/FRONTEND/package.json
@@ -13,8 +13,10 @@
   },
   "dependencies": {
     "@tailwindcss/vite": "^4.2.2",
+    "axios": "^1.15.2",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
+    "react-router-dom": "^7.14.2",
     "tailwindcss": "^4.2.2"
   },
   "devDependencies": {

--- a/FRONTEND/src/App.tsx
+++ b/FRONTEND/src/App.tsx
@@ -1,34 +1,38 @@
-import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
-import LoginPage from './pages/LoginPage';
-import RegisterPage from './pages/RegisterPage';
-import LeaderboardPage from './pages/LeaderboardPage';
-import StatsPage from './pages/StatsPage';
-import HistoryPage from './pages/HistoryPage';
-import GamePage from './pages/GamePage';
-import { useAuth } from './hooks/useAuth';
-import ProtectedRoute from './components/ProtectedRoute';
+import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom'
+import LoginPage from './pages/LoginPage'
+import RegisterPage from './pages/RegisterPage'
+import LeaderboardPage from './pages/LeaderboardPage'
+import StatsPage from './pages/StatsPage'
+import HistoryPage from './pages/HistoryPage'
+import GamePage from './pages/GamePage'
+import { useAuth } from './hooks/useAuth'
+import ProtectedRoute from './components/ProtectedRoute'
 
 const RootRedirect = () => {
-    const { accessToken } = useAuth();
-    return accessToken ? <Navigate to="/leaderboard" replace /> : <Navigate to="/login" replace />;
-};
+  const { accessToken } = useAuth()
+  return accessToken ? (
+    <Navigate to="/leaderboard" replace />
+  ) : (
+    <Navigate to="/login" replace />
+  )
+}
 
 const App = () => {
-    return (
-        <BrowserRouter>
-            <Routes>
-                <Route path="/" element={<RootRedirect />} />
-                <Route path="/login" element={<LoginPage />} />
-                <Route path="/register" element={<RegisterPage />} />
-                <Route element={<ProtectedRoute />}>
-                    <Route path="/leaderboard" element={<LeaderboardPage />} />
-                    <Route path="/stats" element={<StatsPage />} />
-                    <Route path="/history" element={<HistoryPage />} />
-                    <Route path="/play" element={<GamePage />} />
-                </Route>
-            </Routes>
-        </BrowserRouter>
-    );
-};
+  return (
+    <BrowserRouter>
+      <Routes>
+        <Route path="/" element={<RootRedirect />} />
+        <Route path="/login" element={<LoginPage />} />
+        <Route path="/register" element={<RegisterPage />} />
+        <Route element={<ProtectedRoute />}>
+          <Route path="/leaderboard" element={<LeaderboardPage />} />
+          <Route path="/stats" element={<StatsPage />} />
+          <Route path="/history" element={<HistoryPage />} />
+          <Route path="/play" element={<GamePage />} />
+        </Route>
+      </Routes>
+    </BrowserRouter>
+  )
+}
 
-export default App;
+export default App

--- a/FRONTEND/src/App.tsx
+++ b/FRONTEND/src/App.tsx
@@ -1,121 +1,34 @@
-import { useState } from 'react'
-import reactLogo from './assets/react.svg'
-import viteLogo from './assets/vite.svg'
-import heroImg from './assets/hero.png'
-import './App.css'
+import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
+import LoginPage from './pages/LoginPage';
+import RegisterPage from './pages/RegisterPage';
+import LeaderboardPage from './pages/LeaderboardPage';
+import StatsPage from './pages/StatsPage';
+import HistoryPage from './pages/HistoryPage';
+import GamePage from './pages/GamePage';
+import { useAuth } from './hooks/useAuth';
+import ProtectedRoute from './components/ProtectedRoute';
 
-function App() {
-  const [count, setCount] = useState(0)
+const RootRedirect = () => {
+    const { accessToken } = useAuth();
+    return accessToken ? <Navigate to="/leaderboard" replace /> : <Navigate to="/login" replace />;
+};
 
-  return (
-    <>
-      <section id="center">
-        <div className="hero">
-          <img src={heroImg} className="base" width="170" height="179" alt="" />
-          <img src={reactLogo} className="framework" alt="React logo" />
-          <img src={viteLogo} className="vite" alt="Vite logo" />
-        </div>
-        <div>
-          <h1>Get started</h1>
-          <p>
-            Edit <code>src/App.tsx</code> and save to test <code>HMR</code>
-          </p>
-        </div>
-        <button
-          className="counter"
-          onClick={() => setCount((count) => count + 1)}
-        >
-          Count is {count}
-        </button>
-      </section>
+const App = () => {
+    return (
+        <BrowserRouter>
+            <Routes>
+                <Route path="/" element={<RootRedirect />} />
+                <Route path="/login" element={<LoginPage />} />
+                <Route path="/register" element={<RegisterPage />} />
+                <Route element={<ProtectedRoute />}>
+                    <Route path="/leaderboard" element={<LeaderboardPage />} />
+                    <Route path="/stats" element={<StatsPage />} />
+                    <Route path="/history" element={<HistoryPage />} />
+                    <Route path="/play" element={<GamePage />} />
+                </Route>
+            </Routes>
+        </BrowserRouter>
+    );
+};
 
-      <div className="ticks"></div>
-
-      <section id="next-steps">
-        <div id="docs">
-          <svg className="icon" role="presentation" aria-hidden="true">
-            <use href="/icons.svg#documentation-icon"></use>
-          </svg>
-          <h2>Documentation</h2>
-          <p>Your questions, answered</p>
-          <ul>
-            <li>
-              <a href="https://vite.dev/" target="_blank">
-                <img className="logo" src={viteLogo} alt="" />
-                Explore Vite
-              </a>
-            </li>
-            <li>
-              <a href="https://react.dev/" target="_blank">
-                <img className="button-icon" src={reactLogo} alt="" />
-                Learn more
-              </a>
-            </li>
-          </ul>
-        </div>
-        <div id="social">
-          <svg className="icon" role="presentation" aria-hidden="true">
-            <use href="/icons.svg#social-icon"></use>
-          </svg>
-          <h2>Connect with us</h2>
-          <p>Join the Vite community</p>
-          <ul>
-            <li>
-              <a href="https://github.com/vitejs/vite" target="_blank">
-                <svg
-                  className="button-icon"
-                  role="presentation"
-                  aria-hidden="true"
-                >
-                  <use href="/icons.svg#github-icon"></use>
-                </svg>
-                GitHub
-              </a>
-            </li>
-            <li>
-              <a href="https://chat.vite.dev/" target="_blank">
-                <svg
-                  className="button-icon"
-                  role="presentation"
-                  aria-hidden="true"
-                >
-                  <use href="/icons.svg#discord-icon"></use>
-                </svg>
-                Discord
-              </a>
-            </li>
-            <li>
-              <a href="https://x.com/vite_js" target="_blank">
-                <svg
-                  className="button-icon"
-                  role="presentation"
-                  aria-hidden="true"
-                >
-                  <use href="/icons.svg#x-icon"></use>
-                </svg>
-                X.com
-              </a>
-            </li>
-            <li>
-              <a href="https://bsky.app/profile/vite.dev" target="_blank">
-                <svg
-                  className="button-icon"
-                  role="presentation"
-                  aria-hidden="true"
-                >
-                  <use href="/icons.svg#bluesky-icon"></use>
-                </svg>
-                Bluesky
-              </a>
-            </li>
-          </ul>
-        </div>
-      </section>
-
-      <div className="ticks"></div>
-      <section id="spacer"></section>
-    </>
-  )
-}
-
-export default App
+export default App;

--- a/FRONTEND/src/api/client.ts
+++ b/FRONTEND/src/api/client.ts
@@ -1,0 +1,8 @@
+import axios from "axios";
+
+const baseURL = import.meta.env.VITE_API_URL;
+
+export const client = axios.create({
+    baseURL,
+    withCredentials: true,
+});

--- a/FRONTEND/src/api/client.ts
+++ b/FRONTEND/src/api/client.ts
@@ -1,65 +1,68 @@
-import axios from "axios";
-import { getAccessToken, setAccessToken } from "../auth/tokenStore";
+import axios from 'axios'
+import { getAccessToken, setAccessToken } from '../auth/tokenStore'
 
-const baseURL = import.meta.env.VITE_API_URL;
+const baseURL = import.meta.env.VITE_API_URL
 
 export const client = axios.create({
-    baseURL,
-    withCredentials: true,
-});
+  baseURL,
+  withCredentials: true,
+})
 
-let isRefreshing = false;
-let pendingQueue: Array<(token: string | null) => void> = [];
+let isRefreshing = false
+let pendingQueue: Array<(token: string | null) => void> = []
 
 function processPendingQueue(token: string | null) {
-    pendingQueue.forEach(callback => callback(token));
-    pendingQueue = [];
+  pendingQueue.forEach((callback) => callback(token))
+  pendingQueue = []
 }
 
-client.interceptors.request.use(config => {
-    const token = getAccessToken();
-    if (token) {
-        config.headers.Authorization = `Bearer ${token}`;
-    }
-    return config;
-});
+client.interceptors.request.use((config) => {
+  const token = getAccessToken()
+  if (token) {
+    config.headers.Authorization = `Bearer ${token}`
+  }
+  return config
+})
 
-client.interceptors.response.use(response => response, async error => {
-    const originalRequest = error.config;
+client.interceptors.response.use(
+  (response) => response,
+  async (error) => {
+    const originalRequest = error.config
     if (error.response?.status === 401 && !originalRequest._retry) {
-        if (isRefreshing) {
-            return new Promise((resolve, reject) => {
-                pendingQueue.push((token) => {
-                    if (!token) {
-                        reject(error);
-                        return;
-                    }
+      if (isRefreshing) {
+        return new Promise((resolve, reject) => {
+          pendingQueue.push((token) => {
+            if (!token) {
+              reject(error)
+              return
+            }
 
-                    originalRequest.headers.Authorization = `Bearer ${token}`;
-                    resolve(client(originalRequest));
-                });
-            });
-        }
+            originalRequest.headers.Authorization = `Bearer ${token}`
+            resolve(client(originalRequest))
+          })
+        })
+      }
 
-        originalRequest._retry = true;
-        isRefreshing = true;
+      originalRequest._retry = true
+      isRefreshing = true
 
-        try {
-            const response = await client.post("/auth/refresh");
-            const newAccessToken = response.data.accessToken;
+      try {
+        const response = await client.post('/auth/refresh')
+        const newAccessToken = response.data.accessToken
 
-            setAccessToken(newAccessToken);
-            processPendingQueue(newAccessToken);
-            originalRequest.headers.Authorization = `Bearer ${newAccessToken}`;
+        setAccessToken(newAccessToken)
+        processPendingQueue(newAccessToken)
+        originalRequest.headers.Authorization = `Bearer ${newAccessToken}`
 
-            return client(originalRequest);
-        } catch (refreshError) {
-            processPendingQueue(null);
-            return Promise.reject(refreshError);
-        } finally {
-            isRefreshing = false;
-        }
+        return client(originalRequest)
+      } catch (refreshError) {
+        processPendingQueue(null)
+        return Promise.reject(refreshError)
+      } finally {
+        isRefreshing = false
+      }
     }
 
-    return Promise.reject(error);
-});
+    return Promise.reject(error)
+  },
+)

--- a/FRONTEND/src/api/client.ts
+++ b/FRONTEND/src/api/client.ts
@@ -1,8 +1,65 @@
 import axios from "axios";
+import { getAccessToken, setAccessToken } from "../auth/tokenStore";
 
 const baseURL = import.meta.env.VITE_API_URL;
 
 export const client = axios.create({
     baseURL,
     withCredentials: true,
+});
+
+let isRefreshing = false;
+let pendingQueue: Array<(token: string | null) => void> = [];
+
+function processPendingQueue(token: string | null) {
+    pendingQueue.forEach(callback => callback(token));
+    pendingQueue = [];
+}
+
+client.interceptors.request.use(config => {
+    const token = getAccessToken();
+    if (token) {
+        config.headers.Authorization = `Bearer ${token}`;
+    }
+    return config;
+});
+
+client.interceptors.response.use(response => response, async error => {
+    const originalRequest = error.config;
+    if (error.response?.status === 401 && !originalRequest._retry) {
+        if (isRefreshing) {
+            return new Promise((resolve, reject) => {
+                pendingQueue.push((token) => {
+                    if (!token) {
+                        reject(error);
+                        return;
+                    }
+
+                    originalRequest.headers.Authorization = `Bearer ${token}`;
+                    resolve(client(originalRequest));
+                });
+            });
+        }
+
+        originalRequest._retry = true;
+        isRefreshing = true;
+
+        try {
+            const response = await client.post("/auth/refresh");
+            const newAccessToken = response.data.accessToken;
+
+            setAccessToken(newAccessToken);
+            processPendingQueue(newAccessToken);
+            originalRequest.headers.Authorization = `Bearer ${newAccessToken}`;
+
+            return client(originalRequest);
+        } catch (refreshError) {
+            processPendingQueue(null);
+            return Promise.reject(refreshError);
+        } finally {
+            isRefreshing = false;
+        }
+    }
+
+    return Promise.reject(error);
 });

--- a/FRONTEND/src/auth/tokenStore.ts
+++ b/FRONTEND/src/auth/tokenStore.ts
@@ -1,0 +1,9 @@
+let _accessToken: string | null = null;
+
+export const setAccessToken = (token: string | null) => {
+    _accessToken = token;
+};
+
+export const getAccessToken = () => {
+    return _accessToken;
+};

--- a/FRONTEND/src/auth/tokenStore.ts
+++ b/FRONTEND/src/auth/tokenStore.ts
@@ -1,9 +1,9 @@
-let _accessToken: string | null = null;
+let _accessToken: string | null = null
 
 export const setAccessToken = (token: string | null) => {
-    _accessToken = token;
-};
+  _accessToken = token
+}
 
 export const getAccessToken = () => {
-    return _accessToken;
-};
+  return _accessToken
+}

--- a/FRONTEND/src/components/ProtectedRoute.tsx
+++ b/FRONTEND/src/components/ProtectedRoute.tsx
@@ -1,9 +1,9 @@
-import { Navigate, Outlet } from 'react-router-dom';
-import { useAuth } from '../hooks/useAuth';
+import { Navigate, Outlet } from 'react-router-dom'
+import { useAuth } from '../hooks/useAuth'
 
 const ProtectedRoute = () => {
-    const { accessToken } = useAuth();
-    return accessToken ? <Outlet /> : <Navigate to="/login" replace />;
-};
+  const { accessToken } = useAuth()
+  return accessToken ? <Outlet /> : <Navigate to="/login" replace />
+}
 
-export default ProtectedRoute;
+export default ProtectedRoute

--- a/FRONTEND/src/components/ProtectedRoute.tsx
+++ b/FRONTEND/src/components/ProtectedRoute.tsx
@@ -1,0 +1,9 @@
+import { Navigate, Outlet } from 'react-router-dom';
+import { useAuth } from '../hooks/useAuth';
+
+const ProtectedRoute = () => {
+    const { accessToken } = useAuth();
+    return accessToken ? <Outlet /> : <Navigate to="/login" replace />;
+};
+
+export default ProtectedRoute;

--- a/FRONTEND/src/context/AuthContext.ts
+++ b/FRONTEND/src/context/AuthContext.ts
@@ -1,0 +1,13 @@
+import { createContext } from "react";
+
+interface AuthContextType {
+    accessToken: string | null;
+    setAccessToken: (token: string | null) => void;
+    logout: () => void;
+}
+
+export const AuthContext = createContext<AuthContextType>({
+    accessToken: null,
+    setAccessToken: () => {},
+    logout: () => {},
+});

--- a/FRONTEND/src/context/AuthContext.ts
+++ b/FRONTEND/src/context/AuthContext.ts
@@ -1,13 +1,13 @@
-import { createContext } from "react";
+import { createContext } from 'react'
 
 interface AuthContextType {
-    accessToken: string | null;
-    setAccessToken: (token: string | null) => void;
-    logout: () => void;
+  accessToken: string | null
+  setAccessToken: (token: string | null) => void
+  logout: () => void
 }
 
 export const AuthContext = createContext<AuthContextType>({
-    accessToken: null,
-    setAccessToken: () => {},
-    logout: () => {},
-});
+  accessToken: null,
+  setAccessToken: () => {},
+  logout: () => {},
+})

--- a/FRONTEND/src/context/AuthProvider.tsx
+++ b/FRONTEND/src/context/AuthProvider.tsx
@@ -1,21 +1,23 @@
 import { setAccessToken as storeSetAccessToken } from '../auth/tokenStore'
-import { useState, type ReactNode } from "react";
-import { AuthContext } from "./AuthContext";
+import { useState, type ReactNode } from 'react'
+import { AuthContext } from './AuthContext'
 
 export const AuthProvider = ({ children }: { children: ReactNode }) => {
-    const [accessToken, setAccessToken] = useState<string | null>(null);
-    const handleSetAccessToken = (token: string | null) => {
-        storeSetAccessToken(token);   
-        setAccessToken(token);
-    };
+  const [accessToken, setAccessToken] = useState<string | null>(null)
+  const handleSetAccessToken = (token: string | null) => {
+    storeSetAccessToken(token)
+    setAccessToken(token)
+  }
 
-    const logout = () => {
-        handleSetAccessToken(null);
-    };
+  const logout = () => {
+    handleSetAccessToken(null)
+  }
 
-    return (
-        <AuthContext.Provider value={{ accessToken, setAccessToken: handleSetAccessToken, logout }}>
-            {children}
-        </AuthContext.Provider>
-    );
-}; 
+  return (
+    <AuthContext.Provider
+      value={{ accessToken, setAccessToken: handleSetAccessToken, logout }}
+    >
+      {children}
+    </AuthContext.Provider>
+  )
+}

--- a/FRONTEND/src/context/AuthProvider.tsx
+++ b/FRONTEND/src/context/AuthProvider.tsx
@@ -1,21 +1,6 @@
-import { createContext, useContext, useState, type ReactNode } from "react";
 import { setAccessToken as storeSetAccessToken } from '../auth/tokenStore'
-
-interface AuthContextType {
-    accessToken: string | null;
-    setAccessToken: (token: string | null) => void;
-    logout: () => void;
-}
-
-const AuthContext = createContext<AuthContextType>({
-    accessToken: null,
-    setAccessToken: () => {},
-    logout: () => {},
-});
-
-export const useAuth = () => {
-    return useContext(AuthContext);
-};
+import { useState, type ReactNode } from "react";
+import { AuthContext } from "./AuthContext";
 
 export const AuthProvider = ({ children }: { children: ReactNode }) => {
     const [accessToken, setAccessToken] = useState<string | null>(null);

--- a/FRONTEND/src/hooks/useAuth.ts
+++ b/FRONTEND/src/hooks/useAuth.ts
@@ -1,0 +1,6 @@
+import { useContext } from "react";
+import { AuthContext } from "../context/AuthContext";
+
+export const useAuth = () => {
+    return useContext(AuthContext);
+};

--- a/FRONTEND/src/hooks/useAuth.ts
+++ b/FRONTEND/src/hooks/useAuth.ts
@@ -1,6 +1,6 @@
-import { useContext } from "react";
-import { AuthContext } from "../context/AuthContext";
+import { useContext } from 'react'
+import { AuthContext } from '../context/AuthContext'
 
 export const useAuth = () => {
-    return useContext(AuthContext);
-};
+  return useContext(AuthContext)
+}

--- a/FRONTEND/src/hooks/useAuth.tsx
+++ b/FRONTEND/src/hooks/useAuth.tsx
@@ -1,0 +1,36 @@
+import { createContext, useContext, useState, type ReactNode } from "react";
+import { setAccessToken as storeSetAccessToken } from '../auth/tokenStore'
+
+interface AuthContextType {
+    accessToken: string | null;
+    setAccessToken: (token: string | null) => void;
+    logout: () => void;
+}
+
+const AuthContext = createContext<AuthContextType>({
+    accessToken: null,
+    setAccessToken: () => {},
+    logout: () => {},
+});
+
+export const useAuth = () => {
+    return useContext(AuthContext);
+};
+
+export const AuthProvider = ({ children }: { children: ReactNode }) => {
+    const [accessToken, setAccessToken] = useState<string | null>(null);
+    const handleSetAccessToken = (token: string | null) => {
+        storeSetAccessToken(token);   
+        setAccessToken(token);
+    };
+
+    const logout = () => {
+        handleSetAccessToken(null);
+    };
+
+    return (
+        <AuthContext.Provider value={{ accessToken, setAccessToken: handleSetAccessToken, logout }}>
+            {children}
+        </AuthContext.Provider>
+    );
+}; 

--- a/FRONTEND/src/main.tsx
+++ b/FRONTEND/src/main.tsx
@@ -1,10 +1,13 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
+import { AuthProvider } from './hooks/useAuth.tsx'
 import './index.css'
 import App from './App.tsx'
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <App />
+    <AuthProvider>
+      <App />
+    </AuthProvider>
   </StrictMode>,
 )

--- a/FRONTEND/src/main.tsx
+++ b/FRONTEND/src/main.tsx
@@ -1,6 +1,6 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
-import { AuthProvider } from './hooks/useAuth.tsx'
+import { AuthProvider } from './context/AuthProvider.tsx'
 import './index.css'
 import App from './App.tsx'
 

--- a/FRONTEND/src/pages/GamePage.tsx
+++ b/FRONTEND/src/pages/GamePage.tsx
@@ -1,7 +1,7 @@
-import React from 'react';
+import React from 'react'
 
 const GamePage: React.FC = () => {
-    return <div>GamePage</div>;
-};
+  return <div>GamePage</div>
+}
 
-export default GamePage;
+export default GamePage

--- a/FRONTEND/src/pages/GamePage.tsx
+++ b/FRONTEND/src/pages/GamePage.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const GamePage: React.FC = () => {
+    return <div>GamePage</div>;
+};
+
+export default GamePage;

--- a/FRONTEND/src/pages/HistoryPage.tsx
+++ b/FRONTEND/src/pages/HistoryPage.tsx
@@ -1,7 +1,7 @@
-import React from 'react';
+import React from 'react'
 
 const HistoryPage: React.FC = () => {
-    return <div>HistoryPage</div>;
-};
+  return <div>HistoryPage</div>
+}
 
-export default HistoryPage;
+export default HistoryPage

--- a/FRONTEND/src/pages/HistoryPage.tsx
+++ b/FRONTEND/src/pages/HistoryPage.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const HistoryPage: React.FC = () => {
+    return <div>HistoryPage</div>;
+};
+
+export default HistoryPage;

--- a/FRONTEND/src/pages/LeaderboardPage.tsx
+++ b/FRONTEND/src/pages/LeaderboardPage.tsx
@@ -1,7 +1,7 @@
-import React from 'react';
+import React from 'react'
 
 const LeaderboardPage: React.FC = () => {
-    return <div>LeaderboardPage</div>;
-};
+  return <div>LeaderboardPage</div>
+}
 
-export default LeaderboardPage;
+export default LeaderboardPage

--- a/FRONTEND/src/pages/LeaderboardPage.tsx
+++ b/FRONTEND/src/pages/LeaderboardPage.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const LeaderboardPage: React.FC = () => {
+    return <div>LeaderboardPage</div>;
+};
+
+export default LeaderboardPage;

--- a/FRONTEND/src/pages/LoginPage.tsx
+++ b/FRONTEND/src/pages/LoginPage.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const LoginPage: React.FC = () => {
+    return <div>LoginPage</div>;
+};
+
+export default LoginPage;

--- a/FRONTEND/src/pages/LoginPage.tsx
+++ b/FRONTEND/src/pages/LoginPage.tsx
@@ -1,7 +1,7 @@
-import React from 'react';
+import React from 'react'
 
 const LoginPage: React.FC = () => {
-    return <div>LoginPage</div>;
-};
+  return <div>LoginPage</div>
+}
 
-export default LoginPage;
+export default LoginPage

--- a/FRONTEND/src/pages/RegisterPage.tsx
+++ b/FRONTEND/src/pages/RegisterPage.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const RegisterPage: React.FC = () => {
+    return <div>RegisterPage</div>;
+};
+
+export default RegisterPage;

--- a/FRONTEND/src/pages/RegisterPage.tsx
+++ b/FRONTEND/src/pages/RegisterPage.tsx
@@ -1,7 +1,7 @@
-import React from 'react';
+import React from 'react'
 
 const RegisterPage: React.FC = () => {
-    return <div>RegisterPage</div>;
-};
+  return <div>RegisterPage</div>
+}
 
-export default RegisterPage;
+export default RegisterPage

--- a/FRONTEND/src/pages/StatsPage.tsx
+++ b/FRONTEND/src/pages/StatsPage.tsx
@@ -1,7 +1,7 @@
-import React from 'react';
+import React from 'react'
 
 const StatsPage: React.FC = () => {
-    return <div>StatsPage</div>;
-};
+  return <div>StatsPage</div>
+}
 
-export default StatsPage;
+export default StatsPage

--- a/FRONTEND/src/pages/StatsPage.tsx
+++ b/FRONTEND/src/pages/StatsPage.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const StatsPage: React.FC = () => {
+    return <div>StatsPage</div>;
+};
+
+export default StatsPage;

--- a/FRONTEND/src/types/index.ts
+++ b/FRONTEND/src/types/index.ts
@@ -1,0 +1,24 @@
+interface Player {
+    id: string
+    username: string
+    totalMatches: number
+    wins: number
+    losses: number
+    totalScore: number
+}
+
+interface Match {
+    id: string
+    playerId: string
+    teamAScore: number
+    teamBScore: number
+    playerWon: boolean
+    durationSecs: number
+    playedAt: string
+}
+
+interface AuthTokens {
+    accessToken: string
+}
+
+export type { Player, Match, AuthTokens }

--- a/FRONTEND/src/types/index.ts
+++ b/FRONTEND/src/types/index.ts
@@ -1,24 +1,24 @@
 interface Player {
-    id: string
-    username: string
-    totalMatches: number
-    wins: number
-    losses: number
-    totalScore: number
+  id: string
+  username: string
+  totalMatches: number
+  wins: number
+  losses: number
+  totalScore: number
 }
 
 interface Match {
-    id: string
-    playerId: string
-    teamAScore: number
-    teamBScore: number
-    playerWon: boolean
-    durationSecs: number
-    playedAt: string
+  id: string
+  playerId: string
+  teamAScore: number
+  teamBScore: number
+  playerWon: boolean
+  durationSecs: number
+  playedAt: string
 }
 
 interface AuthTokens {
-    accessToken: string
+  accessToken: string
 }
 
 export type { Player, Match, AuthTokens }

--- a/FRONTEND/tsconfig.app.json
+++ b/FRONTEND/tsconfig.app.json
@@ -6,6 +6,7 @@
     "module": "esnext",
     "types": ["vite/client"],
     "skipLibCheck": true,
+    "strict": true,
 
     /* Bundler mode */
     "moduleResolution": "bundler",

--- a/FRONTEND/tsconfig.json
+++ b/FRONTEND/tsconfig.json
@@ -3,5 +3,5 @@
   "references": [
     { "path": "./tsconfig.app.json" },
     { "path": "./tsconfig.node.json" }
-  ],
+  ]
 }

--- a/FRONTEND/tsconfig.json
+++ b/FRONTEND/tsconfig.json
@@ -3,5 +3,6 @@
   "references": [
     { "path": "./tsconfig.app.json" },
     { "path": "./tsconfig.node.json" }
-  ]
+  ],
+  "strict": true
 }

--- a/FRONTEND/tsconfig.json
+++ b/FRONTEND/tsconfig.json
@@ -4,5 +4,4 @@
     { "path": "./tsconfig.app.json" },
     { "path": "./tsconfig.node.json" }
   ],
-  "strict": true
 }


### PR DESCRIPTION
## Summary
- Set up the full React app shell: client-side routing, Axios HTTP client with JWT interceptors, shared TypeScript types, and page scaffolding
- Implemented secure token storage pattern (in-memory access token + httpOnly cookie for refresh) to protect against XSS
- All protected routes guarded via a single `ProtectedRoute` layout component

## Issue
Closes #51

## Changes
- `src/types/index.ts` — `Player`, `Match`, `AuthTokens` TypeScript interfaces
- `src/auth/tokenStore.ts` — module-level token ref for use by Axios interceptor outside React lifecycle
- `src/api/client.ts` — Axios instance with request interceptor (attach Bearer token) and response interceptor (401 → refresh → retry, with `isRefreshing` guard + pending queue to prevent token refresh storms)
- `src/hooks/useAuth.tsx` — `AuthContext` with `accessToken`, `setAccessToken`, `logout`; `setAccessToken` syncs both React state and `tokenStore`
- `src/components/ProtectedRoute.tsx` — layout route that redirects unauthenticated users to `/login`
- `src/App.tsx` — full route tree with public routes (`/login`, `/register`), conditional root redirect, and `ProtectedRoute` layout wrapping all 4 protected pages
- `src/main.tsx` — `AuthProvider` wrapping app at root
- `tsconfig.app.json` — `"strict": true` enabled
- `.env.example` — `VITE_API_URL=http://localhost:8080` committed; `.env` in `.gitignore`
- `package.json` — `axios` and `react-router-dom` added

## Definition of Done
- [x] `react-router-dom` and `axios` installed and listed in `package.json`
- [x] TypeScript strict mode enabled in `tsconfig.json`, project compiles with no errors
- [x] Folder structure created: `api/`, `auth/`, `components/`, `hooks/`, `pages/`, `types/`
- [x] `src/types/index.ts` defines `Player`, `Match`, and `AuthTokens` interfaces
- [x] `src/auth/tokenStore.ts` exports `getAccessToken()` and `setAccessToken()`
- [x] Axios instance in `src/api/client.ts` uses `VITE_API_URL` as base URL
- [x] Request interceptor attaches `Authorization: Bearer <token>` header
- [x] Response interceptor handles 401 → refresh → retry, with `isRefreshing` guard
- [x] Refresh call uses `withCredentials: true` (httpOnly cookie pattern)
- [x] `useAuth.ts` provides `accessToken`, `setAccessToken`, `logout` via React context
- [x] `setAccessToken` in useAuth also calls `tokenStore.setAccessToken()`
- [x] All 6 page components exist and render a placeholder
- [x] `ProtectedRoute` redirects unauthenticated users to `/login`
- [x] React Router configured with all 7 routes (public + protected)
- [x] Root `/` redirects to `/leaderboard` if authenticated, `/login` if not
- [x] `.env.example` committed with `VITE_API_URL=http://localhost:8080`
- [x] `.env` is in `.gitignore`

## Pre-PR Checks
- [x] SOLID principles: ✅ Pass — each file has one job, ProtectedRoute is open for extension
- [x] Naming conventions: ✅ Pass — minor: `baseURL` could be `BASE_URL` (not blocking)
- [x] Documentation: ✅ Pass — self-documenting code, no missing comments

## Notes
- `GamePage` is a placeholder only — WebGL embed is out of scope for this issue
- The refresh interceptor depends on `POST /auth/refresh` (issue #25, already merged) — end-to-end testing requires Kamelia to confirm Gin CORS sets `Access-Control-Allow-Credentials: true` with a specific origin and the refresh cookie uses `SameSite=None; Secure` on Render
- Pages still use `React.FC` type annotation with explicit `React` import — functional but slightly verbose for modern React; can be cleaned up in a future pass