### PR TITLE
[#30] Auth Pages (Register + Login)

### DIFF
--- a/BACKEND/.env.example
+++ b/BACKEND/.env.example
@@ -3,3 +3,4 @@ MONGODB_DB_NAME=waroftanks
 JWT_SECRET=change-me-to-a-random-32-char-string
 JWT_REFRESH_SECRET=change-me-to-another-random-string
 PORT=8080
+FRONTEND_ORIGIN=http://localhost:5173

--- a/BACKEND/README.md
+++ b/BACKEND/README.md
@@ -22,6 +22,7 @@ The API will be available at `http://localhost:8080`.
 | `MONGO_URI`  | MongoDB connection string         |
 | `JWT_SECRET` | Secret key for signing JWT tokens |
 | `PORT`       | Server port (default: 8080)       |
+| `FRONTEND_ORIGIN` | Frontend URL allowed by CORS, defaults to `http://localhost:5173` |
 
 Create a `.env` file in `BACKEND/` with these values before running.
 

--- a/BACKEND/cmd/main.go
+++ b/BACKEND/cmd/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"log"
+	"net/http"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -53,6 +54,7 @@ func main() {
 
 	// Initialize Gin router
 	r := gin.Default()
+	r.Use(corsMiddleware(cfg.FrontendOrigin))
 
 	// Route groups
 	api := r.Group("/api/v1")
@@ -80,5 +82,29 @@ func main() {
 	log.Printf("🚀 Server running on port %s", cfg.Port)
 	if err := r.Run(":" + cfg.Port); err != nil {
 		log.Fatal("Server failed to start:", err)
+	}
+}
+
+func corsMiddleware(frontendOrigin string) gin.HandlerFunc {
+	allowedOrigins := map[string]bool{
+		frontendOrigin:          true,
+		"http://127.0.0.1:5173": true,
+	}
+
+	return func(c *gin.Context) {
+		origin := c.Request.Header.Get("Origin")
+		if allowedOrigins[origin] {
+			c.Header("Access-Control-Allow-Origin", origin)
+			c.Header("Access-Control-Allow-Credentials", "true")
+			c.Header("Access-Control-Allow-Headers", "Content-Type, Authorization")
+			c.Header("Access-Control-Allow-Methods", "GET, POST, PUT, PATCH, DELETE, OPTIONS")
+		}
+
+		if c.Request.Method == http.MethodOptions {
+			c.AbortWithStatus(http.StatusNoContent)
+			return
+		}
+
+		c.Next()
 	}
 }

--- a/BACKEND/cmd/main.go
+++ b/BACKEND/cmd/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"log"
-	"net/http"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -54,7 +53,7 @@ func main() {
 
 	// Initialize Gin router
 	r := gin.Default()
-	r.Use(corsMiddleware(cfg.FrontendOrigin))
+	r.Use(middleware.CORS(cfg.FrontendOrigin))
 
 	// Route groups
 	api := r.Group("/api/v1")
@@ -82,29 +81,5 @@ func main() {
 	log.Printf("🚀 Server running on port %s", cfg.Port)
 	if err := r.Run(":" + cfg.Port); err != nil {
 		log.Fatal("Server failed to start:", err)
-	}
-}
-
-func corsMiddleware(frontendOrigin string) gin.HandlerFunc {
-	allowedOrigins := map[string]bool{
-		frontendOrigin:          true,
-		"http://127.0.0.1:5173": true,
-	}
-
-	return func(c *gin.Context) {
-		origin := c.Request.Header.Get("Origin")
-		if allowedOrigins[origin] {
-			c.Header("Access-Control-Allow-Origin", origin)
-			c.Header("Access-Control-Allow-Credentials", "true")
-			c.Header("Access-Control-Allow-Headers", "Content-Type, Authorization")
-			c.Header("Access-Control-Allow-Methods", "GET, POST, PUT, PATCH, DELETE, OPTIONS")
-		}
-
-		if c.Request.Method == http.MethodOptions {
-			c.AbortWithStatus(http.StatusNoContent)
-			return
-		}
-
-		c.Next()
 	}
 }

--- a/BACKEND/config/config.go
+++ b/BACKEND/config/config.go
@@ -14,6 +14,7 @@ type Config struct {
 	JWTSecret        string
 	JWTRefreshSecret string
 	Port             string
+	FrontendOrigin   string
 }
 
 // Load reads environment variables from .env file and returns a Config.
@@ -26,10 +27,15 @@ func Load() *Config {
 		JWTSecret:        os.Getenv("JWT_SECRET"),
 		JWTRefreshSecret: os.Getenv("JWT_REFRESH_SECRET"),
 		Port:             os.Getenv("PORT"),
+		FrontendOrigin:   os.Getenv("FRONTEND_ORIGIN"),
 	}
 
 	if cfg.MongoURI == "" || cfg.JWTSecret == "" || cfg.MongoDBName == "" {
 		log.Fatal("❌ Missing required environment variables")
+	}
+
+	if cfg.FrontendOrigin == "" {
+		cfg.FrontendOrigin = "http://localhost:5173"
 	}
 
 	return cfg

--- a/BACKEND/handlers/auth_handler.go
+++ b/BACKEND/handlers/auth_handler.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"errors"
 	"net/http"
+	"net/mail"
 	"os"
 	"regexp"
 	"time"
@@ -33,6 +34,7 @@ func NewAuthHandler(db *mongo.Database, jwtSvc *services.JWTService) *AuthHandle
 // RegisterRequest is the expected body for POST /auth/register.
 type RegisterRequest struct {
 	Username string `json:"username" binding:"required"`
+	Email    string `json:"email" binding:"required"`
 	Password string `json:"password" binding:"required"`
 }
 
@@ -47,13 +49,19 @@ type LoginRequest struct {
 func (h *AuthHandler) Register(c *gin.Context) {
 	var req RegisterRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "username and password are required"})
+		c.JSON(http.StatusBadRequest, gin.H{"error": "username, email and password are required"})
 		return
 	}
 
 	// Validate username
 	if !usernameRegex.MatchString(req.Username) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "username must be 3–20 characters (letters, digits, underscore only)"})
+		return
+	}
+
+	// Validate email
+	if _, err := mail.ParseAddress(req.Email); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "email must be valid"})
 		return
 	}
 
@@ -88,7 +96,7 @@ func (h *AuthHandler) Register(c *gin.Context) {
 	player := models.Player{
 		ID:           bson.NewObjectID(),
 		Username:     req.Username,
-		Email:        "", // not required at registration in this task
+		Email:        req.Email,
 		PasswordHash: string(hash),
 		Stats:        models.PlayerStats{},
 		CreatedAt:    now,
@@ -103,6 +111,7 @@ func (h *AuthHandler) Register(c *gin.Context) {
 	c.JSON(http.StatusCreated, gin.H{
 		"id":       player.ID.Hex(),
 		"username": player.Username,
+		"email":    player.Email,
 	})
 }
 

--- a/BACKEND/handlers/auth_test.go
+++ b/BACKEND/handlers/auth_test.go
@@ -97,6 +97,7 @@ func TestRegister_Success(t *testing.T) {
 
 	w := post(r, "/api/v1/auth/register", map[string]string{
 		"username": "alice_01",
+		"email":    "alice@example.com",
 		"password": "securepass",
 	})
 
@@ -113,6 +114,9 @@ func TestRegister_Success(t *testing.T) {
 	if resp["id"] == "" {
 		t.Error("expected non-empty id")
 	}
+	if resp["email"] != "alice@example.com" {
+		t.Errorf("expected email alice@example.com, got %s", resp["email"])
+	}
 
 	// Verify password is hashed in DB
 	var stored models.Player
@@ -126,13 +130,16 @@ func TestRegister_Success(t *testing.T) {
 	if bcrypt.CompareHashAndPassword([]byte(stored.PasswordHash), []byte("securepass")) != nil {
 		t.Error("stored hash does not match plain password")
 	}
+	if stored.Email != "alice@example.com" {
+		t.Errorf("expected stored email alice@example.com, got %s", stored.Email)
+	}
 }
 
 func TestRegister_DuplicateUsername(t *testing.T) {
 	db := setupTestDB(t)
 	r := setupRouter(db)
 
-	body := map[string]string{"username": "bob", "password": "password123"}
+	body := map[string]string{"username": "bob", "email": "bob@example.com", "password": "password123"}
 	post(r, "/api/v1/auth/register", body) // first registration
 
 	w := post(r, "/api/v1/auth/register", body) // duplicate
@@ -147,10 +154,24 @@ func TestRegister_InvalidUsername(t *testing.T) {
 
 	cases := []string{"ab", "toolongusername1234567", "bad name!", "has-hyphen"}
 	for _, u := range cases {
-		w := post(r, "/api/v1/auth/register", map[string]string{"username": u, "password": "password123"})
+		w := post(r, "/api/v1/auth/register", map[string]string{"username": u, "email": "user@example.com", "password": "password123"})
 		if w.Code != http.StatusBadRequest {
 			t.Errorf("username %q: expected 400, got %d", u, w.Code)
 		}
+	}
+}
+
+func TestRegister_InvalidEmail(t *testing.T) {
+	db := setupTestDB(t)
+	r := setupRouter(db)
+
+	w := post(r, "/api/v1/auth/register", map[string]string{
+		"username": "validuser",
+		"email":    "invalid-email",
+		"password": "password123",
+	})
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", w.Code, w.Body.String())
 	}
 }
 
@@ -160,6 +181,7 @@ func TestRegister_ShortPassword(t *testing.T) {
 
 	w := post(r, "/api/v1/auth/register", map[string]string{
 		"username": "validuser",
+		"email":    "valid@example.com",
 		"password": "short",
 	})
 	if w.Code != http.StatusBadRequest {

--- a/BACKEND/middleware/cors.go
+++ b/BACKEND/middleware/cors.go
@@ -1,0 +1,32 @@
+package middleware
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+)
+
+// CORS allows the configured frontend origin to call the API with credentials.
+func CORS(frontendOrigin string) gin.HandlerFunc {
+	allowedOrigins := map[string]bool{
+		frontendOrigin:          true,
+		"http://127.0.0.1:5173": true,
+	}
+
+	return func(c *gin.Context) {
+		origin := c.Request.Header.Get("Origin")
+		if allowedOrigins[origin] {
+			c.Header("Access-Control-Allow-Origin", origin)
+			c.Header("Access-Control-Allow-Credentials", "true")
+			c.Header("Access-Control-Allow-Headers", "Content-Type, Authorization")
+			c.Header("Access-Control-Allow-Methods", "GET, POST, PUT, PATCH, DELETE, OPTIONS")
+		}
+
+		if c.Request.Method == http.MethodOptions {
+			c.AbortWithStatus(http.StatusNoContent)
+			return
+		}
+
+		c.Next()
+	}
+}

--- a/FRONTEND/src/api/client.ts
+++ b/FRONTEND/src/api/client.ts
@@ -28,7 +28,13 @@ client.interceptors.response.use(
   (response) => response,
   async (error) => {
     const originalRequest = error.config
-    if (error.response?.status === 401 && !originalRequest._retry) {
+    const requestUrl = originalRequest?.url ?? ''
+    const canRefresh =
+      !requestUrl.includes('/auth/login') &&
+      !requestUrl.includes('/auth/register') &&
+      !requestUrl.includes('/auth/refresh')
+
+    if (error.response?.status === 401 && canRefresh && !originalRequest._retry) {
       if (isRefreshing) {
         return new Promise((resolve, reject) => {
           pendingQueue.push((token) => {
@@ -47,7 +53,7 @@ client.interceptors.response.use(
       isRefreshing = true
 
       try {
-        const response = await client.post('/auth/refresh')
+        const response = await client.post('/api/v1/auth/refresh')
         const newAccessToken = response.data.accessToken
 
         setAccessToken(newAccessToken)

--- a/FRONTEND/src/api/client.ts
+++ b/FRONTEND/src/api/client.ts
@@ -34,7 +34,11 @@ client.interceptors.response.use(
       !requestUrl.includes('/auth/register') &&
       !requestUrl.includes('/auth/refresh')
 
-    if (error.response?.status === 401 && canRefresh && !originalRequest._retry) {
+    if (
+      error.response?.status === 401 &&
+      canRefresh &&
+      !originalRequest._retry
+    ) {
       if (isRefreshing) {
         return new Promise((resolve, reject) => {
           pendingQueue.push((token) => {

--- a/FRONTEND/src/components/auth/AuthHeading.tsx
+++ b/FRONTEND/src/components/auth/AuthHeading.tsx
@@ -1,0 +1,15 @@
+interface AuthHeadingProps {
+  title: string
+  subtitle: string
+}
+
+const AuthHeading = ({ title, subtitle }: AuthHeadingProps) => (
+  <div className="mb-8">
+    <h1 className="m-0 text-[28px] leading-tight font-semibold tracking-normal text-[#e7ecef]">
+      {title}
+    </h1>
+    <p className="mt-2.5 text-sm text-[#98a1ad]">{subtitle}</p>
+  </div>
+)
+
+export default AuthHeading

--- a/FRONTEND/src/components/auth/AuthLayout.tsx
+++ b/FRONTEND/src/components/auth/AuthLayout.tsx
@@ -1,0 +1,51 @@
+import type { ReactNode } from 'react'
+
+interface AuthLayoutProps {
+  children: ReactNode
+}
+
+const AuthBrand = () => (
+  <div
+    aria-label="War Of Tanks"
+    className="mb-11 flex items-center gap-3 font-mono text-[13px] font-bold tracking-[2.34px] text-[#e7ecef] md:mb-[72px]"
+  >
+    <span className="relative grid size-[22px] place-items-center border border-[#e7ecef]">
+      <span className="size-2.5 border border-[#e7ecef]" />
+      <span className="absolute size-[5px] rounded-full bg-[#5ebc7b]" />
+    </span>
+    <span>WAR OF TANKS</span>
+  </div>
+)
+
+const AuthHero = () => (
+  <section
+    aria-label="War Of Tanks tactical briefing"
+    className="relative min-h-[220px] overflow-hidden border-b border-[#2a313b] bg-[#0e1116] md:min-h-svh md:border-r md:border-b-0"
+  >
+    <div className="absolute bottom-5 left-6 z-10 text-left md:bottom-12 md:left-12">
+      <p className="text-[22px] leading-[1.15] font-semibold tracking-normal text-[#e7ecef] md:text-[28px]">
+        Capture the centre.
+      </p>
+      <span className="mt-2.5 block text-sm text-[#98a1ad]">
+        Hold the zone. Outscore the enemy crew.
+      </span>
+    </div>
+  </section>
+)
+
+const AuthLayout = ({ children }: AuthLayoutProps) => {
+  return (
+    <main className="grid min-h-svh grid-cols-1 overflow-hidden bg-[#0e1116] text-[#e7ecef] md:grid-cols-2">
+      <AuthHero />
+
+      <section className="grid min-h-0 place-items-center bg-[#0e1116] px-5 py-9 md:min-h-svh md:p-12">
+        <div className="w-full max-w-[380px] text-left">
+          <AuthBrand />
+          {children}
+        </div>
+      </section>
+    </main>
+  )
+}
+
+export default AuthLayout

--- a/FRONTEND/src/components/auth/AuthMessage.tsx
+++ b/FRONTEND/src/components/auth/AuthMessage.tsx
@@ -1,0 +1,24 @@
+type AuthMessageVariant = 'error' | 'success'
+
+interface AuthMessageProps {
+  children: string
+  className?: string
+  variant: AuthMessageVariant
+}
+
+const variantClasses: Record<AuthMessageVariant, string> = {
+  error:
+    "relative pl-4 text-xs leading-snug text-[#ee6951] before:absolute before:top-[0.65em] before:left-0 before:size-1.5 before:-translate-y-1/2 before:rounded-full before:bg-[#ee6951] before:content-['']",
+  success:
+    'rounded border border-[rgba(94,188,123,0.45)] bg-[rgba(94,188,123,0.10)] px-3.5 py-3 text-[13px] text-[#8fe0a9]',
+}
+
+const AuthMessage = ({
+  children,
+  className = '',
+  variant,
+}: AuthMessageProps) => (
+  <p className={`${variantClasses[variant]} ${className}`}>{children}</p>
+)
+
+export default AuthMessage

--- a/FRONTEND/src/components/auth/AuthSubmitButton.tsx
+++ b/FRONTEND/src/components/auth/AuthSubmitButton.tsx
@@ -1,0 +1,26 @@
+import type { ButtonHTMLAttributes } from 'react'
+
+interface AuthSubmitButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  isLoading: boolean
+  label: string
+  loadingLabel: string
+}
+
+const AuthSubmitButton = ({
+  isLoading,
+  label,
+  loadingLabel,
+  ...buttonProps
+}: AuthSubmitButtonProps) => (
+  <button
+    className="flex min-h-[45px] w-full cursor-pointer items-center justify-between rounded bg-[#5ebc7b] px-4 text-sm font-bold text-[#0a0d10] transition hover:-translate-y-px hover:bg-[#71d391] disabled:cursor-not-allowed disabled:opacity-70 disabled:hover:translate-y-0 disabled:hover:bg-[#5ebc7b]"
+    disabled={isLoading || buttonProps.disabled}
+    type="submit"
+    {...buttonProps}
+  >
+    <span>{isLoading ? loadingLabel : label}</span>
+    <span aria-hidden="true">↵</span>
+  </button>
+)
+
+export default AuthSubmitButton

--- a/FRONTEND/src/components/auth/AuthSwitchLink.tsx
+++ b/FRONTEND/src/components/auth/AuthSwitchLink.tsx
@@ -1,0 +1,18 @@
+import { Link } from 'react-router-dom'
+
+interface AuthSwitchLinkProps {
+  label: string
+  linkLabel: string
+  to: string
+}
+
+const AuthSwitchLink = ({ label, linkLabel, to }: AuthSwitchLinkProps) => (
+  <p className="mt-6 text-center text-sm text-[#98a1ad]">
+    {label}{' '}
+    <Link className="text-[#e7ecef] no-underline hover:text-[#5dcbd1]" to={to}>
+      {linkLabel}
+    </Link>
+  </p>
+)
+
+export default AuthSwitchLink

--- a/FRONTEND/src/components/auth/AuthTextField.tsx
+++ b/FRONTEND/src/components/auth/AuthTextField.tsx
@@ -1,0 +1,40 @@
+import type { InputHTMLAttributes } from 'react'
+
+interface AuthTextFieldProps extends InputHTMLAttributes<HTMLInputElement> {
+  hasError?: boolean
+  label: string
+  error?: string
+}
+
+const AuthTextField = ({
+  hasError = false,
+  label,
+  error,
+  className = '',
+  ...inputProps
+}: AuthTextFieldProps) => {
+  const isInvalid = hasError || Boolean(error)
+  const inputClassName = [
+    'w-full rounded border bg-[#11161d] px-3.5 py-[13px] text-sm text-[#e7ecef] outline-none transition placeholder:text-[#6b7280] focus:border-[#5dcbd1] focus:shadow-[0_0_0_3px_rgba(93,203,209,0.16)]',
+    isInvalid
+      ? 'border-[#ee6951] shadow-[0_0_0_3px_rgba(238,105,81,0.18)]'
+      : 'border-[#2a313b]',
+    className,
+  ]
+    .filter(Boolean)
+    .join(' ')
+
+  return (
+    <label className="flex flex-col gap-2">
+      <span className="font-mono text-[10.5px] tracking-[1.05px] text-[#98a1ad]">
+        {label}
+      </span>
+      <input className={inputClassName} {...inputProps} />
+      {error && (
+        <small className="text-xs leading-snug text-[#ee6951]">{error}</small>
+      )}
+    </label>
+  )
+}
+
+export default AuthTextField

--- a/FRONTEND/src/context/AuthContext.ts
+++ b/FRONTEND/src/context/AuthContext.ts
@@ -1,13 +1,12 @@
 import { createContext } from 'react'
+import type { Player } from '../types'
 
 interface AuthContextType {
+  player: Player | null
   accessToken: string | null
   setAccessToken: (token: string | null) => void
-  logout: () => void
+  login: (username: string, password: string) => Promise<void>
+  logout: () => Promise<void>
 }
 
-export const AuthContext = createContext<AuthContextType>({
-  accessToken: null,
-  setAccessToken: () => {},
-  logout: () => {},
-})
+export const AuthContext = createContext<AuthContextType | undefined>(undefined)

--- a/FRONTEND/src/context/AuthProvider.tsx
+++ b/FRONTEND/src/context/AuthProvider.tsx
@@ -1,21 +1,84 @@
 import { setAccessToken as storeSetAccessToken } from '../auth/tokenStore'
 import { useState, type ReactNode } from 'react'
 import { AuthContext } from './AuthContext'
+import { client } from '../api/client'
+import type { Player } from '../types'
+
+interface LoginResponsePlayer {
+  id: string
+  username: string
+  email?: string
+  totalMatches?: number
+  wins?: number
+  losses?: number
+  totalScore?: number
+  stats?: {
+    totalMatches?: number
+    wins?: number
+    losses?: number
+    totalScore?: number
+  }
+}
+
+interface LoginResponse {
+  accessToken: string
+  player: LoginResponsePlayer
+}
+
+const normalizePlayer = (player: LoginResponsePlayer): Player => ({
+  id: player.id,
+  username: player.username,
+  email: player.email ?? '',
+  totalMatches: player.stats?.totalMatches ?? player.totalMatches ?? 0,
+  wins: player.stats?.wins ?? player.wins ?? 0,
+  losses: player.stats?.losses ?? player.losses ?? 0,
+  totalScore: player.stats?.totalScore ?? player.totalScore ?? 0,
+})
 
 export const AuthProvider = ({ children }: { children: ReactNode }) => {
+  const [player, setPlayer] = useState<Player | null>(null)
   const [accessToken, setAccessToken] = useState<string | null>(null)
+
   const handleSetAccessToken = (token: string | null) => {
     storeSetAccessToken(token)
     setAccessToken(token)
   }
 
-  const logout = () => {
-    handleSetAccessToken(null)
+  const login = async (username: string, password: string) => {
+    const response = await client.post<LoginResponse>('/api/v1/auth/login', {
+      username,
+      password,
+    })
+
+    setPlayer(normalizePlayer(response.data.player))
+    handleSetAccessToken(response.data.accessToken)
+  }
+
+  const logout = async () => {
+    try {
+      await client.post('/api/v1/auth/logout')
+    } finally {
+      setPlayer(null)
+      handleSetAccessToken(null)
+    }
+  }
+
+  const setTokenOnly = (token: string | null) => {
+    if (!token) {
+      setPlayer(null)
+    }
+    handleSetAccessToken(token)
   }
 
   return (
     <AuthContext.Provider
-      value={{ accessToken, setAccessToken: handleSetAccessToken, logout }}
+      value={{
+        player,
+        accessToken,
+        setAccessToken: setTokenOnly,
+        login,
+        logout,
+      }}
     >
       {children}
     </AuthContext.Provider>

--- a/FRONTEND/src/hooks/useAuth.ts
+++ b/FRONTEND/src/hooks/useAuth.ts
@@ -2,5 +2,10 @@ import { useContext } from 'react'
 import { AuthContext } from '../context/AuthContext'
 
 export const useAuth = () => {
-  return useContext(AuthContext)
+  const context = useContext(AuthContext)
+  if (!context) {
+    throw new Error('useAuth must be used inside AuthProvider')
+  }
+
+  return context
 }

--- a/FRONTEND/src/index.css
+++ b/FRONTEND/src/index.css
@@ -52,12 +52,15 @@
   }
 }
 
+html {
+  background: #0e1116;
+}
+
 #root {
-  width: 1126px;
+  width: 100%;
   max-width: 100%;
   margin: 0 auto;
   text-align: center;
-  border-inline: 1px solid var(--border);
   min-height: 100svh;
   display: flex;
   flex-direction: column;
@@ -66,6 +69,7 @@
 
 body {
   margin: 0;
+  min-width: 320px;
 }
 
 h1,

--- a/FRONTEND/src/pages/LoginPage.tsx
+++ b/FRONTEND/src/pages/LoginPage.tsx
@@ -1,7 +1,104 @@
-import React from 'react'
+import { useEffect, useState } from 'react'
+import type { FormEvent } from 'react'
+import { useLocation, useNavigate } from 'react-router-dom'
+import AuthHeading from '../components/auth/AuthHeading'
+import AuthLayout from '../components/auth/AuthLayout'
+import AuthMessage from '../components/auth/AuthMessage'
+import AuthSubmitButton from '../components/auth/AuthSubmitButton'
+import AuthSwitchLink from '../components/auth/AuthSwitchLink'
+import AuthTextField from '../components/auth/AuthTextField'
+import { useAuth } from '../hooks/useAuth'
 
-const LoginPage: React.FC = () => {
-  return <div>LoginPage</div>
+interface LoginLocationState {
+  message?: string
+}
+
+const LoginPage = () => {
+  const navigate = useNavigate()
+  const location = useLocation()
+  const { player, login } = useAuth()
+  const state = location.state as LoginLocationState | null
+
+  const [username, setUsername] = useState('')
+  const [password, setPassword] = useState('')
+  const [error, setError] = useState('')
+  const [isSubmitting, setIsSubmitting] = useState(false)
+
+  useEffect(() => {
+    if (player) {
+      navigate('/leaderboard', { replace: true })
+    }
+  }, [navigate, player])
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    setError('')
+    setIsSubmitting(true)
+
+    try {
+      await login(username.trim(), password)
+      navigate('/leaderboard', { replace: true })
+    } catch {
+      setError('Invalid username or password')
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  return (
+    <AuthLayout>
+      <AuthHeading
+        subtitle="Pick up your tank crew where you left them."
+        title="Sign in"
+      />
+
+      {state?.message && (
+        <AuthMessage className="mb-[18px]" variant="success">
+          {state.message}
+        </AuthMessage>
+      )}
+
+      <form
+        className="flex flex-col gap-[18px]"
+        onSubmit={handleSubmit}
+        noValidate
+      >
+        <AuthTextField
+          autoComplete="username"
+          hasError={Boolean(error)}
+          label="USERNAME"
+          name="username"
+          onChange={(event) => setUsername(event.target.value)}
+          type="text"
+          value={username}
+        />
+
+        <AuthTextField
+          autoComplete="current-password"
+          hasError={Boolean(error)}
+          label="PASSWORD"
+          name="password"
+          onChange={(event) => setPassword(event.target.value)}
+          type="password"
+          value={password}
+        />
+
+        {error && <AuthMessage variant="error">{error}</AuthMessage>}
+
+        <AuthSubmitButton
+          isLoading={isSubmitting}
+          label="Login"
+          loadingLabel="Logging in"
+        />
+      </form>
+
+      <AuthSwitchLink
+        label="No account yet?"
+        linkLabel="Create one"
+        to="/register"
+      />
+    </AuthLayout>
+  )
 }
 
 export default LoginPage

--- a/FRONTEND/src/pages/RegisterPage.tsx
+++ b/FRONTEND/src/pages/RegisterPage.tsx
@@ -19,8 +19,8 @@ interface RegisterErrors {
   form?: string
 }
 
-const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
-const usernamePattern = /^[a-zA-Z0-9_]{3,20}$/
+const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+const USERNAME_PATTERN = /^[a-zA-Z0-9_]{3,20}$/
 
 const RegisterPage = () => {
   const navigate = useNavigate()
@@ -44,11 +44,11 @@ const RegisterPage = () => {
     const trimmedUsername = username.trim()
     const trimmedEmail = email.trim()
 
-    if (!usernamePattern.test(trimmedUsername)) {
+    if (!USERNAME_PATTERN.test(trimmedUsername)) {
       nextErrors.username = 'Use 3-20 letters, numbers, or underscores'
     }
 
-    if (!emailPattern.test(trimmedEmail)) {
+    if (!EMAIL_PATTERN.test(trimmedEmail)) {
       nextErrors.email = 'Enter a valid email address'
     }
 

--- a/FRONTEND/src/pages/RegisterPage.tsx
+++ b/FRONTEND/src/pages/RegisterPage.tsx
@@ -1,7 +1,177 @@
-import React from 'react'
+import { useEffect, useState } from 'react'
+import type { FormEvent } from 'react'
+import { isAxiosError } from 'axios'
+import { useNavigate } from 'react-router-dom'
+import AuthHeading from '../components/auth/AuthHeading'
+import AuthLayout from '../components/auth/AuthLayout'
+import AuthMessage from '../components/auth/AuthMessage'
+import AuthSubmitButton from '../components/auth/AuthSubmitButton'
+import AuthSwitchLink from '../components/auth/AuthSwitchLink'
+import AuthTextField from '../components/auth/AuthTextField'
+import { client } from '../api/client'
+import { useAuth } from '../hooks/useAuth'
 
-const RegisterPage: React.FC = () => {
-  return <div>RegisterPage</div>
+interface RegisterErrors {
+  username?: string
+  email?: string
+  password?: string
+  confirmPassword?: string
+  form?: string
+}
+
+const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+const usernamePattern = /^[a-zA-Z0-9_]{3,20}$/
+
+const RegisterPage = () => {
+  const navigate = useNavigate()
+  const { player } = useAuth()
+
+  const [username, setUsername] = useState('')
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+  const [confirmPassword, setConfirmPassword] = useState('')
+  const [errors, setErrors] = useState<RegisterErrors>({})
+  const [isSubmitting, setIsSubmitting] = useState(false)
+
+  useEffect(() => {
+    if (player) {
+      navigate('/leaderboard', { replace: true })
+    }
+  }, [navigate, player])
+
+  const validate = () => {
+    const nextErrors: RegisterErrors = {}
+    const trimmedUsername = username.trim()
+    const trimmedEmail = email.trim()
+
+    if (!usernamePattern.test(trimmedUsername)) {
+      nextErrors.username = 'Use 3-20 letters, numbers, or underscores'
+    }
+
+    if (!emailPattern.test(trimmedEmail)) {
+      nextErrors.email = 'Enter a valid email address'
+    }
+
+    if (password.length < 8) {
+      nextErrors.password = 'Password must be at least 8 characters'
+    }
+
+    if (confirmPassword !== password) {
+      nextErrors.confirmPassword = 'Passwords do not match'
+    }
+
+    return nextErrors
+  }
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+
+    const validationErrors = validate()
+    setErrors(validationErrors)
+
+    if (Object.keys(validationErrors).length > 0) {
+      return
+    }
+
+    setIsSubmitting(true)
+
+    try {
+      await client.post('/api/v1/auth/register', {
+        username: username.trim(),
+        email: email.trim(),
+        password,
+      })
+
+      navigate('/login', {
+        replace: true,
+        state: { message: 'Account created. You can sign in now.' },
+      })
+    } catch (error) {
+      if (isAxiosError(error) && error.response?.status === 409) {
+        setErrors({ username: 'Username already taken' })
+        return
+      }
+
+      setErrors({ form: 'Could not create account. Try again.' })
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  return (
+    <AuthLayout>
+      <AuthHeading
+        subtitle="One callsign, one tank crew."
+        title="Create account"
+      />
+
+      {errors.form && (
+        <AuthMessage className="mb-[18px]" variant="error">
+          {errors.form}
+        </AuthMessage>
+      )}
+
+      <form
+        className="flex flex-col gap-[18px]"
+        onSubmit={handleSubmit}
+        noValidate
+      >
+        <AuthTextField
+          autoComplete="username"
+          error={errors.username}
+          label="USERNAME - 3-20 CHARS"
+          name="username"
+          onChange={(event) => setUsername(event.target.value)}
+          placeholder="callsign"
+          type="text"
+          value={username}
+        />
+
+        <AuthTextField
+          autoComplete="email"
+          error={errors.email}
+          label="EMAIL"
+          name="email"
+          onChange={(event) => setEmail(event.target.value)}
+          placeholder="email"
+          type="email"
+          value={email}
+        />
+
+        <AuthTextField
+          autoComplete="new-password"
+          error={errors.password}
+          label="PASSWORD - MIN 8 CHARS"
+          name="password"
+          onChange={(event) => setPassword(event.target.value)}
+          type="password"
+          value={password}
+        />
+
+        <AuthTextField
+          autoComplete="new-password"
+          error={errors.confirmPassword}
+          label="CONFIRM PASSWORD"
+          name="confirmPassword"
+          onChange={(event) => setConfirmPassword(event.target.value)}
+          type="password"
+          value={confirmPassword}
+        />
+
+        <AuthSubmitButton
+          isLoading={isSubmitting}
+          label="Create account"
+          loadingLabel="Creating account"
+        />
+      </form>
+
+      <AuthSwitchLink
+        label="Already deployed?"
+        linkLabel="Sign in"
+        to="/login"
+      />
+    </AuthLayout>
+  )
 }
 
 export default RegisterPage

--- a/FRONTEND/src/types/index.ts
+++ b/FRONTEND/src/types/index.ts
@@ -1,6 +1,7 @@
 interface Player {
   id: string
   username: string
+  email: string
   totalMatches: number
   wins: number
   losses: number


### PR DESCRIPTION
## Summary
- Implemented Login and Register pages with full form validation, loading states, and API integration
- Built 6 reusable auth UI components (AuthLayout, AuthTextField, AuthSubmitButton, AuthMessage, AuthHeading, AuthSwitchLink)
- Wired AuthContext and AuthProvider with real `login` / `logout` API calls and player state
- Fixed Axios refresh interceptor to avoid infinite 401 loop on auth routes
- Added email field to registration (backend + frontend + tests)
- Added CORS middleware to Go backend with configurable `FRONTEND_ORIGIN` env var

## Issue
Closes #30

## Changes
- `BACKEND/cmd/main.go` — added `corsMiddleware()` for frontend CORS support
- `BACKEND/config/config.go` — added `FrontendOrigin` field with default fallback
- `BACKEND/.env.example` — documented `FRONTEND_ORIGIN` variable
- `BACKEND/handlers/auth_handler.go` — email field made required at registration with `mail.ParseAddress` validation
- `BACKEND/handlers/auth_test.go` — updated all registration tests to include email; added `TestRegister_InvalidEmail`
- `FRONTEND/src/context/AuthContext.ts` — added `player`, `login`, `logout` to context type; default changed to `undefined`
- `FRONTEND/src/context/AuthProvider.tsx` — implemented `login()` (POST /auth/login), `logout()` (POST /auth/logout), `normalizePlayer` helper
- `FRONTEND/src/hooks/useAuth.ts` — added null guard throwing if used outside `AuthProvider`
- `FRONTEND/src/api/client.ts` — guarded refresh interceptor against auth routes; fixed refresh URL to `/api/v1/auth/refresh`
- `FRONTEND/src/components/auth/` — 6 new reusable auth components
- `FRONTEND/src/pages/LoginPage.tsx` — full login form with redirect guard and success message support
- `FRONTEND/src/pages/RegisterPage.tsx` — full register form with per-field validation and 409 conflict handling
- `FRONTEND/src/types/index.ts` — added `email` to `Player` interface
- `FRONTEND/src/index.css` — dark background, full-width layout, min-width 320px

## Definition of Done
- [x] Register form with validation (client-side + API errors displayed)
- [x] Login form working and redirecting on success
- [x] Access token stored in React context (NOT localStorage)
- [x] Errors from API displayed clearly to the user
- [x] Loading states shown on form submission
- [x] Both pages are responsive (tested at 375px and 1280px width)
- [x] Redirects: logged-in users going to `/login` are redirected to `/leaderboard`
- [x] Naming convention check passed — ⚠️ minor: `emailPattern`/`usernamePattern` in RegisterPage should be `EMAIL_PATTERN`/`USERNAME_PATTERN`

## Pre-PR Checks
- ✅ SOLID principles: all components single-responsibility; minor — `corsMiddleware` could move to `middleware/cors.go` (follow-up)
- ⚠️ Naming conventions: `emailPattern`/`usernamePattern` should be `SCREAMING_SNAKE_CASE` per TS convention
- ✅ Documentation: godoc on all exported Go methods; React components self-documented via typed props

## Notes
- `corsMiddleware` is currently in `main.go` for simplicity; recommend moving to `middleware/cors.go` in a follow-up cleanup
- `normalizePlayer` handles both flat and nested stats shapes from the backend to future-proof the login response
- Email uniqueness is not yet enforced at the DB level (no unique index on `email`) — follow-up in a migration if needed