### PR TITLE
[#28] Backend Unit Tests & CI Integration

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -16,20 +16,8 @@ jobs:
     name: Go Tests
     runs-on: ubuntu-latest
 
-    services:
-      mongodb:
-        image: mongo:7
-        ports:
-          - 27017:27017
-        options: >-
-          --health-cmd "mongosh --eval 'db.runCommand({ ping: 1 })'"
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-
     env:
-      MONGODB_URI: ${{ secrets.MONGODB_URI_TEST != '' && secrets.MONGODB_URI_TEST || 'mongodb://localhost:27017' }}
-      MONGODB_DB_NAME: war_of_tanks_test
+      MONGODB_TEST_URI: mongodb://localhost:27017/?replicaSet=rs0
       JWT_SECRET: ci-test-secret
       JWT_REFRESH_SECRET: ci-test-refresh-secret
       PORT: 8080
@@ -37,6 +25,13 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+
+      - name: Start MongoDB replica set
+        run: |
+          docker run -d --name mongodb -p 27017:27017 mongo:7 mongod --replSet rs0 --bind_ip_all
+          until docker exec mongodb mongosh --quiet --eval "db.adminCommand('ping')" 2>/dev/null; do sleep 2; done
+          docker exec mongodb mongosh --eval "rs.initiate({_id:'rs0',members:[{_id:0,host:'localhost:27017'}]})"
+          until docker exec mongodb mongosh --quiet --eval "db.hello().isWritablePrimary" 2>/dev/null | grep -q true; do sleep 2; done
 
       - name: Set up Go
         uses: actions/setup-go@v5

--- a/BACKEND/README.md
+++ b/BACKEND/README.md
@@ -30,15 +30,32 @@ Create a `.env` file in `BACKEND/` with these values before running.
 
 > Routes marked ✅ are live. Others are in progress — see issues below.
 
-| Method | Route                   | Description                  | Status  |
-| ------ | ----------------------- | ---------------------------- | ------- |
-| POST   | `/api/v1/auth/register` | Register a new player        | ✅ Live |
-| POST   | `/api/v1/auth/login`    | Login and receive JWT tokens | ✅ Live |
-| POST   | `/api/v1/auth/refresh`  | Refresh access token         | 🔲 #26  |
-| GET    | `/api/v1/players/:id`   | Get player profile           | 🔲 #27  |
-| GET    | `/api/v1/matches`       | Get match history            | 🔲 #27  |
-| POST   | `/api/v1/matches`       | Record a match result        | 🔲 #27  |
-| GET    | `/api/v1/leaderboard`   | Get leaderboard              | 🔲 #27  |
+| Method | Route                   | Description                                          | Status  |
+| ------ | ----------------------- | ---------------------------------------------------- | ------- |
+| POST   | `/api/v1/auth/register` | Register a new player                                | ✅ Live |
+| POST   | `/api/v1/auth/login`    | Login and receive JWT tokens                         | ✅ Live |
+| POST   | `/api/v1/auth/refresh`  | Refresh access token via HttpOnly cookie             | ✅ Live |
+| POST   | `/api/v1/auth/logout`   | Clear refresh token cookie                           | ✅ Live |
+| GET    | `/api/v1/players`       | Leaderboard — all players sorted by score, paginated | ✅ Live |
+| GET    | `/api/v1/players/me`    | Authenticated player's own profile                   | ✅ Live |
+| POST   | `/api/v1/matches`       | Record a match result (atomic transaction)           | ✅ Live |
+| GET    | `/api/v1/matches`       | Authenticated player's match history, paginated      | ✅ Live |
+
+## Running Tests
+
+Tests require a real MongoDB instance (no mocking). For local development:
+
+```bash
+# With a local MongoDB running on localhost:27017
+go test ./... -v
+
+# With a replica set (needed for SaveMatch transaction tests)
+MONGODB_TEST_URI="mongodb://localhost:27017/?replicaSet=rs0" go test ./... -v -race
+```
+
+Tests that require a replica set skip automatically when one is not available.
+
+The CI pipeline starts MongoDB 7 with a single-node replica set before running `go test ./... -v -race -coverprofile=coverage.out`.
 
 ## JWT Strategy
 
@@ -54,9 +71,9 @@ Create a `.env` file in `BACKEND/` with these values before running.
 | [#24](https://github.com/oussema-fatnassi/WarOfTanks/issues/24) | Backend Project Setup (Go + Gin + MongoDB + Docker)                | ✅ Done     |
 | [#54](https://github.com/oussama-fatnassi/WarOfTanks/issues/54) | MongoDB Database Initialization — Collections, Indexes & Seed Data | ✅ Done     |
 | [#25](https://github.com/oussema-fatnassi/WarOfTanks/issues/25) | Player Model & Auth Routes (Register + Login)                      | ✅ Done     |
-| [#26](https://github.com/oussema-fatnassi/WarOfTanks/issues/26) | JWT Auth Middleware & Refresh Token Route                          | Not started |
-| [#27](https://github.com/oussema-fatnassi/WarOfTanks/issues/27) | Player & Match Routes                                              | Not started |
-| [#28](https://github.com/oussema-fatnassi/WarOfTanks/issues/28) | Backend Unit Tests & CI Integration                                | Not started |
+| [#26](https://github.com/oussema-fatnassi/WarOfTanks/issues/26) | JWT Auth Middleware & Refresh Token Route                          | ✅ Done     |
+| [#27](https://github.com/oussema-fatnassi/WarOfTanks/issues/27) | Player & Match Routes                                              | ✅ Done     |
+| [#28](https://github.com/oussema-fatnassi/WarOfTanks/issues/28) | Backend Unit Tests & CI Integration                                | ✅ Done     |
 | [#5](https://github.com/oussema-fatnassi/WarOfTanks/issues/5)   | GitHub Actions - Backend CI                                        | ✅ Done     |
 
 ## Architecture Notes

--- a/BACKEND/handlers/match_handler_test.go
+++ b/BACKEND/handlers/match_handler_test.go
@@ -157,6 +157,99 @@ func TestGetMatches_RequiresAuth(t *testing.T) {
 	}
 }
 
+// skipIfNoReplicaSet skips the test when MongoDB is running in standalone mode.
+// SaveMatch uses multi-document transactions which require a replica set.
+func skipIfNoReplicaSet(t *testing.T, client *mongo.Client) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	if err := client.Database("admin").RunCommand(ctx, bson.D{{Key: "replSetGetStatus", Value: 1}}).Err(); err != nil {
+		t.Skip("replica set not available — skipping transaction test")
+	}
+}
+
+// ── POST /matches success ─────────────────────────────────────────────────────
+
+func TestSaveMatch_Success_PlayerWins(t *testing.T) {
+	db, client := setupTestDBWithClient(t)
+	skipIfNoReplicaSet(t, client)
+	r, jwtSvc := setupMatchRouter(db, client)
+
+	player := seedPlayerWithStats(t, db, "winner_player", 0)
+	token, _ := jwtSvc.GenerateAccessToken(player.ID.Hex(), player.Username)
+
+	w := authPost(r, "/api/v1/matches", map[string]interface{}{
+		"winnerTeam":  1,
+		"playerScore": 80,
+		"aiScore":     40,
+		"duration":    120.5,
+	}, token)
+
+	if w.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp map[string]interface{}
+	_ = json.Unmarshal(w.Body.Bytes(), &resp)
+	if resp["winnerTeam"].(float64) != 1 {
+		t.Errorf("expected winnerTeam 1, got %v", resp["winnerTeam"])
+	}
+	if resp["playerScore"].(float64) != 80 {
+		t.Errorf("expected playerScore 80, got %v", resp["playerScore"])
+	}
+
+	var updated models.Player
+	if err := db.Collection("players").FindOne(context.Background(), bson.D{{Key: "_id", Value: player.ID}}).Decode(&updated); err != nil {
+		t.Fatalf("player not found after match save: %v", err)
+	}
+	if updated.Stats.Wins != 1 {
+		t.Errorf("expected wins=1, got %d", updated.Stats.Wins)
+	}
+	if updated.Stats.Losses != 0 {
+		t.Errorf("expected losses=0, got %d", updated.Stats.Losses)
+	}
+	if updated.Stats.TotalMatches != 1 {
+		t.Errorf("expected totalMatches=1, got %d", updated.Stats.TotalMatches)
+	}
+	if updated.Stats.TotalScore != 80 {
+		t.Errorf("expected totalScore=80, got %.0f", updated.Stats.TotalScore)
+	}
+}
+
+func TestSaveMatch_Success_AIWins(t *testing.T) {
+	db, client := setupTestDBWithClient(t)
+	skipIfNoReplicaSet(t, client)
+	r, jwtSvc := setupMatchRouter(db, client)
+
+	player := seedPlayerWithStats(t, db, "loser_player", 0)
+	token, _ := jwtSvc.GenerateAccessToken(player.ID.Hex(), player.Username)
+
+	w := authPost(r, "/api/v1/matches", map[string]interface{}{
+		"winnerTeam":  2,
+		"playerScore": 20,
+		"aiScore":     100,
+		"duration":    90.0,
+	}, token)
+
+	if w.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var updated models.Player
+	if err := db.Collection("players").FindOne(context.Background(), bson.D{{Key: "_id", Value: player.ID}}).Decode(&updated); err != nil {
+		t.Fatalf("player not found after match save: %v", err)
+	}
+	if updated.Stats.Losses != 1 {
+		t.Errorf("expected losses=1, got %d", updated.Stats.Losses)
+	}
+	if updated.Stats.Wins != 0 {
+		t.Errorf("expected wins=0, got %d", updated.Stats.Wins)
+	}
+	if updated.Stats.TotalScore != 20 {
+		t.Errorf("expected totalScore=20, got %.0f", updated.Stats.TotalScore)
+	}
+}
+
 func TestGetMatches_RespectsLimit(t *testing.T) {
 	db, client := setupTestDBWithClient(t)
 	r, jwtSvc := setupMatchRouter(db, client)

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -95,6 +95,7 @@ npm run dev
 - ✅ [#27](https://github.com/oussema-fatnassi/WarOfTanks/issues/27) Player & Match Routes — `GET /players` leaderboard (sorted by score, paginated), `GET /players/me`, `POST /matches` (MongoDB transaction: saves match + updates player stats atomically), `GET /matches` (own history, paginated), all routes protected by JWT middleware
 - ✅ [#22](https://github.com/oussema-fatnassi/WarOfTanks/issues/22) AI - Tank Behaviour Trees (Specializations) — 3 AI roles (Captor, Attacker, Defender) each with a priority-ordered BT; TankBlackboard data snapshot; VisionSystem stub; GameManager tank registry; partial class TankAI split across 5 files; Enemy.prefab updated
 - ✅ [#30](https://github.com/oussema-fatnassi/WarOfTanks/issues/30) Auth Pages (Register + Login) — two-column auth layout, login/register pages with form validation, AuthContext + AuthProvider + useAuth hook, Axios refresh interceptor guard, CORS middleware, email required at registration
+- ✅ [#28](https://github.com/oussema-fatnassi/WarOfTanks/issues/28) Backend Unit Tests & CI Integration — comprehensive handler tests (auth, player, match) against real MongoDB; CI updated to MongoDB replica set for transaction support; `go test -race -coverprofile`; `TestSaveMatch` covers win/loss stats update atomically
 
 ## In Progress / Remaining
 
@@ -113,7 +114,7 @@ npm run dev
 | [#20](https://github.com/oussema-fatnassi/WarOfTanks/issues/20) | Fog of War (WebGL-Compatible)               | Oroitz  | High     | Not started |
 | [#22](https://github.com/oussema-fatnassi/WarOfTanks/issues/22) | AI - Tank Behaviour Trees (Specializations) | Oroitz  | Critical | Not started |
 | [#27](https://github.com/oussema-fatnassi/WarOfTanks/issues/27) | Player & Match Routes                       | Kamelia | High     | ✅ Done  |
-| [#28](https://github.com/oussema-fatnassi/WarOfTanks/issues/28) | Backend Unit Tests & CI Integration         | Kamelia | High     | Not started |
+| [#28](https://github.com/oussema-fatnassi/WarOfTanks/issues/28) | Backend Unit Tests & CI Integration         | Kamelia | High     | ✅ Done  |
 
 ### Sprint 5 — Integration & Delivery (May 25 – May 31)
 


### PR DESCRIPTION
## Summary

- Updated CI pipeline to start MongoDB 7 as a **single-node replica set**, enabling multi-document transaction support required by `SaveMatch`
- Added `TestSaveMatch_Success_PlayerWins` and `TestSaveMatch_Success_AIWins` — cover the full match save path (match document created + player stats updated atomically)
- Added `skipIfNoReplicaSet` helper so transaction tests skip gracefully when running locally without a replica set
- Updated `BACKEND/README.md`: corrected API endpoint table (all routes now ✅ Live), added **Running Tests** section, marked #26/#27/#28 as Done
- Updated root `ReadMe.md`: #28 moved to Features Completed, Sprint 4 table status updated to ✅ Done

## Test plan

- [x] CI pipeline green on this PR (Backend CI with replica set MongoDB)
- [x] `go test ./... -v` passes locally when MongoDB is available
- [x] `TestSaveMatch_Success_*` skip (not fail) when running locally without a replica set
- [x] `TestSaveMatch_BadRequest_*` and `TestGetMatches_*` still pass (no regression)
- [x] README reflects the correct live API routes and test instructions

## Closes

Closes #28
