### PR TITLE
[#19] Detection System - Field of View

### DIFF
--- a/UNITY/Assets/Prefabs/Tanks/Tank.prefab
+++ b/UNITY/Assets/Prefabs/Tanks/Tank.prefab
@@ -452,8 +452,11 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 04898e17ebc5a4cfcb456d6bb9309cc2, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _detectionRadius: 0
-  _fieldOfViewAngle: 0
+  _detectionRadius: 6
+  _fieldOfViewAngle: 360
+  _obstacleLayerMask:
+    serializedVersion: 2
+    m_Bits: 1536
 --- !u!1 &773176153051293553
 GameObject:
   m_ObjectHideFlags: 0

--- a/UNITY/Assets/Scenes/FeaturesTesting/BehaviourTree.unity
+++ b/UNITY/Assets/Scenes/FeaturesTesting/BehaviourTree.unity
@@ -8154,6 +8154,22 @@ PrefabInstance:
       propertyPath: _role
       value: 2
       objectReference: {fileID: 0}
+    - target: {fileID: 6231303744932298063, guid: 47b7d6e16d1164b36b6d441ec28f7b63, type: 3}
+      propertyPath: _showDebugLogs
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6231303744932298063, guid: 47b7d6e16d1164b36b6d441ec28f7b63, type: 3}
+      propertyPath: _detectionRadius
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 6231303744932298063, guid: 47b7d6e16d1164b36b6d441ec28f7b63, type: 3}
+      propertyPath: _fieldOfViewAngle
+      value: 360
+      objectReference: {fileID: 0}
+    - target: {fileID: 6231303744932298063, guid: 47b7d6e16d1164b36b6d441ec28f7b63, type: 3}
+      propertyPath: _obstacleLayerMask.m_Bits
+      value: 1536
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 47b7d6e16d1164b36b6d441ec28f7b63, type: 3}
 --- !u!1 &305643270
@@ -8800,6 +8816,46 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 4703835614537488591, guid: a90906032f594de4fbf5530fc7895a69, type: 3}
   m_PrefabInstance: {fileID: 591256964}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &660325751 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 773176152485814613, guid: 8c3bdc1bc81e82f49acf03aaac5e8b65, type: 3}
+  m_PrefabInstance: {fileID: 2057617217}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &660325760
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 660325751}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a0c233f21812b804d9936b50dafffbb2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _scanInterval: 0.1
+  _aimTolerance: 10
+  _showDebugLogs: 1
+--- !u!1 &700422529 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 773176152485814613, guid: 8c3bdc1bc81e82f49acf03aaac5e8b65, type: 3}
+  m_PrefabInstance: {fileID: 1904058766}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &700422538
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 700422529}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a0c233f21812b804d9936b50dafffbb2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _scanInterval: 0.1
+  _aimTolerance: 10
+  _showDebugLogs: 1
 --- !u!1001 &797123547
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -8870,6 +8926,22 @@ PrefabInstance:
     - target: {fileID: 5609634953105270565, guid: 47b7d6e16d1164b36b6d441ec28f7b63, type: 3}
       propertyPath: _role
       value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6231303744932298063, guid: 47b7d6e16d1164b36b6d441ec28f7b63, type: 3}
+      propertyPath: _showDebugLogs
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6231303744932298063, guid: 47b7d6e16d1164b36b6d441ec28f7b63, type: 3}
+      propertyPath: _detectionRadius
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 6231303744932298063, guid: 47b7d6e16d1164b36b6d441ec28f7b63, type: 3}
+      propertyPath: _fieldOfViewAngle
+      value: 360
+      objectReference: {fileID: 0}
+    - target: {fileID: 6231303744932298063, guid: 47b7d6e16d1164b36b6d441ec28f7b63, type: 3}
+      propertyPath: _obstacleLayerMask.m_Bits
+      value: 1536
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 47b7d6e16d1164b36b6d441ec28f7b63, type: 3}
@@ -9561,6 +9633,26 @@ TilemapCollider2D:
   m_Offset: {x: 0, y: 0}
   m_MaximumTileChangeCount: 1000
   m_ExtrusionFactor: 0.00001
+--- !u!1 &998530104 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 773176152485814613, guid: 8c3bdc1bc81e82f49acf03aaac5e8b65, type: 3}
+  m_PrefabInstance: {fileID: 119331258}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &998530113
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 998530104}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a0c233f21812b804d9936b50dafffbb2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _scanInterval: 0.1
+  _aimTolerance: 10
+  _showDebugLogs: 1
 --- !u!1 &1008525846
 GameObject:
   m_ObjectHideFlags: 0
@@ -11984,5 +12076,21 @@ PrefabInstance:
       propertyPath: _bulletPool
       value: 
       objectReference: {fileID: 591256965}
+    - target: {fileID: 6231303744932298063, guid: 47b7d6e16d1164b36b6d441ec28f7b63, type: 3}
+      propertyPath: _showDebugLogs
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6231303744932298063, guid: 47b7d6e16d1164b36b6d441ec28f7b63, type: 3}
+      propertyPath: _detectionRadius
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 6231303744932298063, guid: 47b7d6e16d1164b36b6d441ec28f7b63, type: 3}
+      propertyPath: _fieldOfViewAngle
+      value: 360
+      objectReference: {fileID: 0}
+    - target: {fileID: 6231303744932298063, guid: 47b7d6e16d1164b36b6d441ec28f7b63, type: 3}
+      propertyPath: _obstacleLayerMask.m_Bits
+      value: 1536
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 47b7d6e16d1164b36b6d441ec28f7b63, type: 3}

--- a/UNITY/Assets/Scenes/FeaturesTesting/MergeControlsGridNavigation.unity
+++ b/UNITY/Assets/Scenes/FeaturesTesting/MergeControlsGridNavigation.unity
@@ -11549,6 +11549,18 @@ PrefabInstance:
       propertyPath: m_Name
       value: ENEMY1
       objectReference: {fileID: 0}
+    - target: {fileID: 1991546480952036511, guid: 8c3bdc1bc81e82f49acf03aaac5e8b65, type: 3}
+      propertyPath: _detectionRadius
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 1991546480952036511, guid: 8c3bdc1bc81e82f49acf03aaac5e8b65, type: 3}
+      propertyPath: _fieldOfViewAngle
+      value: 360
+      objectReference: {fileID: 0}
+    - target: {fileID: 1991546480952036511, guid: 8c3bdc1bc81e82f49acf03aaac5e8b65, type: 3}
+      propertyPath: _obstacleLayerMask.m_Bits
+      value: 1536
+      objectReference: {fileID: 0}
     - target: {fileID: 8066777654821941431, guid: 8c3bdc1bc81e82f49acf03aaac5e8b65, type: 3}
       propertyPath: _teamId
       value: 1

--- a/UNITY/Assets/Scripts/AI/TankAI.Actions.cs
+++ b/UNITY/Assets/Scripts/AI/TankAI.Actions.cs
@@ -74,7 +74,10 @@ namespace WarOfTanks.AI
             Vector2 currentPosition = transform.position;
 
             if (Vector2.Distance(currentPosition, enemyPosition) <= _tank.FiringRange)
+            {
+                ClearPath();
                 return NodeStatus.Success;
+            }
 
             Vector2Int targetGrid = _grid.WorldToGridPosition(enemy.transform.position);
 
@@ -229,6 +232,48 @@ namespace WarOfTanks.AI
             }
 
             return NodeStatus.Success;
+        }
+
+        /// <summary>
+        /// Patrols back and forth between own spawn and the nearest enemy spawn.
+        /// Toggles direction each time the tank reaches the current waypoint.
+        /// Falls back to patrol when the attacker loses line of sight on all enemies.
+        /// </summary>
+        private NodeStatus PatrolBetweenSpawns()
+        {
+            if (_blackboard == null || _grid == null || _tank == null || GameManager.Instance == null)
+                return NodeStatus.Failure;
+
+            List<Tank> allTanks = GameManager.Instance.GetAllTanks();
+
+            Tank enemyTank = null;
+            foreach (Tank tank in allTanks)
+            {
+                if (tank != null && tank.TeamId == _blackboard.enemyTeamId)
+                {
+                    enemyTank = tank;
+                    break;
+                }
+            }
+
+            if (enemyTank == null) return NodeStatus.Failure;
+
+            Vector3 enemySpawn = enemyTank.SpawnPosition;
+            Vector3 ownSpawn = _tank.SpawnPosition;
+            Vector3 currentWaypoint = _patrolTowardEnemy ? enemySpawn : ownSpawn;
+
+            if (Vector2.Distance(transform.position, currentWaypoint) < 1f)
+            {
+                _patrolTowardEnemy = !_patrolTowardEnemy;
+                currentWaypoint = _patrolTowardEnemy ? enemySpawn : ownSpawn;
+            }
+
+            Vector2Int targetGrid = _grid.WorldToGridPosition(currentWaypoint);
+
+            if (IsAlreadyMovingTo(targetGrid)) return NodeStatus.Running;
+
+            SetDestination(targetGrid);
+            return NodeStatus.Running;
         }
 
         /// <summary>

--- a/UNITY/Assets/Scripts/AI/TankAI.AttackerTree.cs
+++ b/UNITY/Assets/Scripts/AI/TankAI.AttackerTree.cs
@@ -20,19 +20,20 @@ namespace WarOfTanks.AI
                     new ActionNode(MoveToSpawn)
                 }),
 
-                // Enemy visible -> move into range -> attack
+                // Enemy visible with line of sight -> chase -> attack
                 new Sequence(new List<IBehaviourNode>
                 {
-                    new ConditionNode(() => 
+                    new ConditionNode(() =>
                         _blackboard != null &&
                         _blackboard.closestEnemy != null &&
-                        _blackboard.closestEnemy.target != null),
+                        _blackboard.closestEnemy.target != null &&
+                        _blackboard.closestEnemy.isInLineOfSight),
                     new ActionNode(MoveToFiringRange),
                     new ActionNode(AttackClosestEnemy)
                 }),
 
-                // Default -> patrol toward enemy spawn
-                new ActionNode(PatrolToEnemySpawn)
+                // Default -> patrol between own spawn and enemy spawn
+                new ActionNode(PatrolBetweenSpawns)
             });
 
             return new BehaviourTreeController(root);

--- a/UNITY/Assets/Scripts/AI/TankAI.cs
+++ b/UNITY/Assets/Scripts/AI/TankAI.cs
@@ -48,6 +48,7 @@ namespace WarOfTanks.AI
         private bool _isWaiting;
         private bool _isHandlingBlock;
         private Vector2 _lastBlockerPosition;
+        private bool _patrolTowardEnemy = true;
         private INavigable _navigator;
         private NavigationGrid _grid;
         private TankController _tankController;

--- a/UNITY/Assets/Scripts/AI/TankBlackboard.cs
+++ b/UNITY/Assets/Scripts/AI/TankBlackboard.cs
@@ -1,5 +1,5 @@
 using System.Collections.Generic;
-
+using UnityEditor;
 using WarOfTanks.Enums;
 using ZoneController = WarOfTanks.Zone.Zone;
 
@@ -36,7 +36,7 @@ namespace WarOfTanks.AI
         /// <summary>
         /// Refreshes the blackboard values before the behaviour tree is ticked.
         /// </summary>
-        public void Update(VisionSystem vision, List<Tank> allTanks)
+        public void Update(IVisionSystem vision, List<Tank> allTanks)
         {
             if (self == null)
             {

--- a/UNITY/Assets/Scripts/AI/VisionSystem.cs
+++ b/UNITY/Assets/Scripts/AI/VisionSystem.cs
@@ -5,20 +5,47 @@ using WarOfTanks.Enums;
 namespace WarOfTanks.AI
 {
     /// <summary>
-    /// Stub detection component used by tank behaviour trees until the real vision logic is implemented.
+    /// Detection component — scans for enemy tanks within radius and verifies line of sight via raycasts.
     /// </summary>
-    public class VisionSystem : MonoBehaviour 
+    public class VisionSystem : MonoBehaviour, IVisionSystem
     {
         [SerializeField] private float _detectionRadius;
         [SerializeField] private float _fieldOfViewAngle;
+        [SerializeField] private LayerMask _obstacleLayerMask;
+        [SerializeField] private bool _showDebugLogs;
 
         /// <summary>
         /// Scans all tanks and returns detection results for enemies of the owner team.
         /// </summary>
         public List<DetectionResult> Scan(List<Tank> allTanks, ETankTeam ownerTeamId)
         {
-            // TODO: implement real detection in issue #19.
-            return new List<DetectionResult>();
+            List<DetectionResult> results = new List<DetectionResult>();
+
+            if (allTanks == null) return results;
+
+            foreach (Tank tank in allTanks)
+            {
+                if (tank == null || !tank.IsAlive) continue;
+                if (tank.gameObject == gameObject) continue;
+                if (tank.TeamId == ownerTeamId) continue;
+
+                float distance = Vector2.Distance(transform.position, tank.transform.position);
+                if (distance > _detectionRadius) continue;
+
+                Vector2 direction = ((Vector2)(tank.transform.position - transform.position)).normalized;
+                float angle = Vector2.Angle(transform.up, direction);
+
+                bool blocked = Physics2D.Linecast(transform.position, tank.transform.position, _obstacleLayerMask);
+                bool isInLineOfSight = !blocked;
+
+                results.Add(new DetectionResult(tank, distance, angle, isInLineOfSight));
+
+                DebugLogger.Log(_showDebugLogs, $"[VisionSystem] {gameObject.name} → {tank.name} | dist: {distance:F1} | LoS: {isInLineOfSight}");
+            }
+
+            DebugLogger.Log(_showDebugLogs, $"[VisionSystem] {gameObject.name} scan done — {results.Count} enemies in range");
+
+            return results;
         }
 
 
@@ -27,8 +54,22 @@ namespace WarOfTanks.AI
         /// </summary>
         public DetectionResult GetClosestTarget(List<DetectionResult> results)
         {
-            // TODO: implement real target selection in issue #19.
-            return null;
+            if (results == null || results.Count == 0) return null;
+
+            DetectionResult closest = null;
+
+            foreach (DetectionResult result in results)
+            {
+                if (closest == null || result.distance < closest.distance)
+                    closest = result;
+            }
+
+            return closest;
+        }
+        private void OnDrawGizmosSelected()
+        {
+            Gizmos.color = new Color(1f, 1f, 0f, 0.3f);
+            Gizmos.DrawWireSphere(transform.position, _detectionRadius);
         }
     }
 }

--- a/UNITY/Assets/Scripts/Interfaces/IVisionSystem.cs
+++ b/UNITY/Assets/Scripts/Interfaces/IVisionSystem.cs
@@ -2,8 +2,18 @@ using System.Collections.Generic;
 using WarOfTanks.AI;
 using WarOfTanks.Enums;
 
+/// <summary>
+/// Contract for a component that detects enemy tanks within a radius and verifies line of sight.
+/// </summary>
 public interface IVisionSystem
 {
+    /// <summary>
+    /// Scans the provided tank list and returns detection results for enemies of the owner team.
+    /// </summary>
     List<DetectionResult> Scan(List<Tank> allTanks, ETankTeam ownerTeamId);
+
+    /// <summary>
+    /// Returns the detection result with the smallest distance, or null if the list is empty.
+    /// </summary>
     DetectionResult GetClosestTarget(List<DetectionResult> results);
 }

--- a/UNITY/Assets/Scripts/Interfaces/IVisionSystem.cs
+++ b/UNITY/Assets/Scripts/Interfaces/IVisionSystem.cs
@@ -1,0 +1,9 @@
+using System.Collections.Generic;
+using WarOfTanks.AI;
+using WarOfTanks.Enums;
+
+public interface IVisionSystem
+{
+    List<DetectionResult> Scan(List<Tank> allTanks, ETankTeam ownerTeamId);
+    DetectionResult GetClosestTarget(List<DetectionResult> results);
+}

--- a/UNITY/Assets/Scripts/Interfaces/IVisionSystem.cs.meta
+++ b/UNITY/Assets/Scripts/Interfaces/IVisionSystem.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0353dd210f1403c4c8dc4832777b5cca
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UNITY/Assets/Scripts/Tanks/PlayerAutoAim.cs
+++ b/UNITY/Assets/Scripts/Tanks/PlayerAutoAim.cs
@@ -21,6 +21,7 @@ public class PlayerAutoAim : MonoBehaviour
     private Tank _tank;
     private DetectionResult _currentTarget;
 
+    /// <summary>Caches required components.</summary>
     private void Awake()
     {
         _visionSystem = GetComponent<VisionSystem>();
@@ -28,11 +29,15 @@ public class PlayerAutoAim : MonoBehaviour
         _tank = GetComponent<Tank>();
     }
 
+    /// <summary>Starts the repeating scan coroutine.</summary>
     private void Start()
     {
         StartCoroutine(ScanRoutine());
     }
 
+    /// <summary>
+    /// Repeatedly calls <see cref="UpdateTarget"/> on the configured scan interval.
+    /// </summary>
     private IEnumerator ScanRoutine()
     {
         while (true)
@@ -42,6 +47,9 @@ public class PlayerAutoAim : MonoBehaviour
         }
     }
 
+    /// <summary>
+    /// Runs a vision scan and updates <see cref="_currentTarget"/> to the closest enemy with line of sight.
+    /// </summary>
     private void UpdateTarget()
     {
         List<Tank> allTanks = GameManager.Instance != null
@@ -60,6 +68,10 @@ public class PlayerAutoAim : MonoBehaviour
         DebugLogger.Log(_showDebugLogs, $"[PlayerAutoAim] {gameObject.name} target: {(_currentTarget != null ? _currentTarget.target.name : "none")}");
     }
 
+    /// <summary>
+    /// Each frame, rotates the turret toward the current target and fires when aimed and ready.
+    /// Clears the target if it dies or goes missing.
+    /// </summary>
     private void Update()
     {
         if (_currentTarget == null || _currentTarget.target == null || !_currentTarget.target.IsAlive)

--- a/UNITY/Assets/Scripts/Tanks/PlayerAutoAim.cs
+++ b/UNITY/Assets/Scripts/Tanks/PlayerAutoAim.cs
@@ -1,0 +1,80 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using WarOfTanks.AI;
+
+/// <summary>
+/// Automatically aims and fires the turret at the nearest visible enemy.
+/// The player retains full control of movement. Add this alongside VisionSystem on player tank prefabs.
+/// </summary>
+[RequireComponent(typeof(VisionSystem))]
+[RequireComponent(typeof(TurretController))]
+[RequireComponent(typeof(Tank))]
+public class PlayerAutoAim : MonoBehaviour
+{
+    [SerializeField] private float _scanInterval = 0.1f;
+    [SerializeField] private float _aimTolerance = 10f;
+    [SerializeField] private bool _showDebugLogs;
+
+    private VisionSystem _visionSystem;
+    private TurretController _turretController;
+    private Tank _tank;
+    private DetectionResult _currentTarget;
+
+    private void Awake()
+    {
+        _visionSystem = GetComponent<VisionSystem>();
+        _turretController = GetComponent<TurretController>();
+        _tank = GetComponent<Tank>();
+    }
+
+    private void Start()
+    {
+        StartCoroutine(ScanRoutine());
+    }
+
+    private IEnumerator ScanRoutine()
+    {
+        while (true)
+        {
+            yield return new WaitForSeconds(_scanInterval);
+            UpdateTarget();
+        }
+    }
+
+    private void UpdateTarget()
+    {
+        List<Tank> allTanks = GameManager.Instance != null
+            ? GameManager.Instance.GetAllTanks()
+            : new List<Tank>();
+
+        List<DetectionResult> results = _visionSystem.Scan(allTanks, _tank.TeamId);
+
+        List<DetectionResult> visibleEnemies = new List<DetectionResult>();
+        foreach (DetectionResult r in results)
+        {
+            if (r.isInLineOfSight) visibleEnemies.Add(r);
+        }
+
+        _currentTarget = _visionSystem.GetClosestTarget(visibleEnemies);
+        DebugLogger.Log(_showDebugLogs, $"[PlayerAutoAim] {gameObject.name} target: {(_currentTarget != null ? _currentTarget.target.name : "none")}");
+    }
+
+    private void Update()
+    {
+        if (_currentTarget == null || _currentTarget.target == null || !_currentTarget.target.IsAlive)
+        {
+            _currentTarget = null;
+            return;
+        }
+
+        Vector2 targetPos = _currentTarget.target.transform.position;
+        _turretController.RotateTo(targetPos);
+
+        if (_turretController.IsAimedAt(targetPos, _aimTolerance) && _turretController.CanFire)
+        {
+            _turretController.Fire();
+            DebugLogger.Log(_showDebugLogs, $"[PlayerAutoAim] {gameObject.name} fired at {_currentTarget.target.name}");
+        }
+    }
+}

--- a/UNITY/Assets/Scripts/Tanks/PlayerAutoAim.cs.meta
+++ b/UNITY/Assets/Scripts/Tanks/PlayerAutoAim.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a0c233f21812b804d9936b50dafffbb2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UNITY/Assets/Scripts/Tanks/TurretController.cs
+++ b/UNITY/Assets/Scripts/Tanks/TurretController.cs
@@ -54,7 +54,10 @@ public class TurretController : MonoBehaviour
 
         GameObject bulletObject = Instantiate(_bulletPrefab, _cannonTipTransform.position, _cannonTipTransform.rotation, _bulletPool);
         BulletController bulletController = bulletObject.GetComponent<BulletController>();
-        Physics2D.IgnoreCollision(bulletObject.GetComponent<Collider2D>(), GetComponentInChildren<Collider2D>());
+        Collider2D tankCollider = GetComponentInParent<Collider2D>();
+        Collider2D bulletCollider = bulletObject.GetComponent<Collider2D>();
+        if (tankCollider != null && bulletCollider != null)
+            Physics2D.IgnoreCollision(bulletCollider, tankCollider);
 
 
         // TODO : Maybe call initialize with damage, speed , etc. if needed in the future.

--- a/UNITY/Assets/Scripts/Tanks/TurretController.cs
+++ b/UNITY/Assets/Scripts/Tanks/TurretController.cs
@@ -22,6 +22,7 @@ public class TurretController : MonoBehaviour
     #endregion
 
     #region Getters
+    /// <summary>Returns true when enough time has elapsed since the last shot to fire again.</summary>
     public bool CanFire => Time.time >= _lastFireTime + 1f / _fireRate;
     #endregion
 
@@ -33,6 +34,9 @@ public class TurretController : MonoBehaviour
     #endregion
 
     #region Public Methods
+    /// <summary>
+    /// Rotates the turret toward the target position at the configured rotation speed.
+    /// </summary>
     public void RotateTo(Vector2 targetPosition)
     {
         Vector2 direction = targetPosition - (Vector2)_turretTransform.position;
@@ -40,6 +44,9 @@ public class TurretController : MonoBehaviour
         _turretTransform.rotation = Quaternion.RotateTowards(_turretTransform.rotation, Quaternion.Euler(0, 0, targetAngle), _turretRotationSpeed * Time.deltaTime);
     }
 
+    /// <summary>
+    /// Returns true when the angle between the turret forward and the direction to the target is within the tolerance.
+    /// </summary>
     public bool IsAimedAt(Vector2 targetPosition, float toleranceDegrees)
     {
         Vector2 toTarget = (targetPosition - (Vector2)_turretTransform.position).normalized;
@@ -47,6 +54,10 @@ public class TurretController : MonoBehaviour
         return angle <= toleranceDegrees;
     }
 
+    /// <summary>
+    /// Spawns a bullet from the cannon tip and launches it forward. Pass <c>force = true</c> to bypass the fire rate cooldown.
+    /// Returns the spawned <see cref="BulletController"/>, or null if the cooldown has not elapsed.
+    /// </summary>
     public BulletController Fire(bool force = false)
     {
         if (!CanFire && !force) return null;


### PR DESCRIPTION
## Summary
- Implemented `VisionSystem` MonoBehaviour — scans for enemy tanks within `_detectionRadius` using `Physics2D.Linecast` for per-target line-of-sight verification
- Added `IVisionSystem` interface to decouple the vision contract from consumers (migration of `PlayerAutoAim` and `TankBlackboard` is a follow-up)
- Implemented `TankBlackboard.Update()` with enemy filtering, health ratio tracking, and safe null-guards
- Built `TankAI.Actions.cs` with all 9 behaviour tree action nodes (move, patrol, attack, retreat)
- Built `TankAI.AttackerTree.cs` — attacker role tree: retreat when low HP, pursue + attack visible enemies, patrol between spawns as fallback
- Added `PlayerAutoAim` component — reuses `VisionSystem` to auto-aim and fire the player turret at the nearest visible enemy

## Issue
Closes #19

## Changes
- `AI/VisionSystem.cs` — `Scan()` + `GetClosestTarget()` + `OnDrawGizmosSelected()` gizmo, `_obstacleLayerMask` SerializeField
- `Interfaces/IVisionSystem.cs` — new interface defining the vision contract
- `AI/TankBlackboard.cs` — `Update()`, `FilterValidEnemies()`, `GetHealthRatio()`, `ClearDetectionData()`
- `AI/TankAI.cs` — `TickBehaviourTree()`, `BuildBehaviourTree()`, `BuildIdleTree()`, VisionSystem wiring
- `AI/TankAI.Actions.cs` — `MoveToZone`, `MoveToSpawn`, `MoveToFiringRange`, `MoveToZonePerimeter`, `MoveToIntercept`, `PatrolToEnemySpawn`, `PatrolZoneToSpawn`, `AttackClosestEnemy`, `PatrolBetweenSpawns`, `SignalEnemyVisible`
- `AI/TankAI.AttackerTree.cs` — attacker role behaviour tree
- `Tanks/PlayerAutoAim.cs` — new component for player-side auto-aim via VisionSystem
- `Tanks/TurretController.cs` — `RotateTo()`, `IsAimedAt()`, `Fire()` with bullet spawning and self-collision ignore

## Definition of Done
- [x] `VisionSystem` component scans for objects within radius
- [x] `Scan()` returns detection results with correct enemy data
- [x] Line-of-sight raycast correctly blocked by Cover and Obstacle layers
- [x] Enemy tanks behind walls are NOT detected (`isInLineOfSight = false`)
- [x] Enemy tanks in open view ARE detected (`isInLineOfSight = true`)
- [x] Scan performance: 0.1s timer via `TankAI.TickBehaviourTree()` — no per-frame scan
- [x] Debug Gizmos: vision radius circle drawn in Scene view
- [x] SOLID principles check passed
- [x] Naming convention check passed
- [ ] Control zone detected when within radius — deferred, not in current sprint scope

## Pre-PR Checks
- [x] SOLID principles: ✅ Pass — no blocking violations (`PlayerAutoAim` uses concrete `VisionSystem` type, follow-up to migrate to `IVisionSystem`)
- [x] Naming conventions: ✅ Pass — 0 violations across all files
- [x] Documentation: ✅ Pass — minor gaps on `IVisionSystem` and `TurretController` public methods, not blocking

## Notes
- `IVisionSystem` interface was added but `PlayerAutoAim` and `TankBlackboard` still reference `VisionSystem` directly — migration is a low-priority follow-up before #20 (Fog of War)
- `_fieldOfViewAngle` is declared but not used for filtering — scan is always 360° by design. Field kept for future use.
- `TurretController.Fire()` uses `Instantiate` directly — known tech debt, tracked in the TODO comment
- `SignalEnemyVisible()` is a stub returning `Running` — commander AI not yet implemented