### PR TITLE
feat: Leaderboard, Stats & Match History pages

### DIFF
--- a/FRONTEND/README.md
+++ b/FRONTEND/README.md
@@ -42,7 +42,7 @@ FRONTEND/
 │   ├── api/          # Axios client with JWT interceptors
 │   ├── assets/       # Images and SVGs
 │   ├── auth/         # tokenStore — module-level token ref for interceptor
-│   ├── components/   # Reusable UI components (ProtectedRoute)
+│   ├── components/   # Reusable UI components (Navbar, ProtectedRoute, StatCard, WinLossBar, ErrorBanner, PageHeader, SkeletonRows)
 │   ├── context/      # AuthContext + AuthProvider
 │   ├── hooks/        # Custom React hooks (useAuth)
 │   ├── pages/        # One file per route
@@ -73,7 +73,7 @@ FRONTEND/
 | [#29](https://github.com/oussema-fatnassi/WarOfTanks/issues/29) | Frontend Project Setup (Vite + React + TypeScript)           | ✅ Done     |
 | [#51](https://github.com/oussema-fatnassi/WarOfTanks/issues/51) | Frontend App Structure — Routing, Axios Client, Types, Pages | ✅ Done     |
 | [#30](https://github.com/oussema-fatnassi/WarOfTanks/issues/30) | Auth Pages (Register + Login)                                | ✅ Done     |
-| [#31](https://github.com/oussema-fatnassi/WarOfTanks/issues/31) | Leaderboard, Stats & Match History Pages                     | Not started |
+| [#31](https://github.com/oussema-fatnassi/WarOfTanks/issues/31) | Leaderboard, Stats & Match History Pages                     | ✅ Done     |
 | [#32](https://github.com/oussema-fatnassi/WarOfTanks/issues/32) | WebGL Game Embed                                             | Not started |
 | [#6](https://github.com/oussema-fatnassi/WarOfTanks/issues/6)   | GitHub Actions - Code Quality (ESLint + Prettier)            | ✅ Done     |
 

--- a/FRONTEND/src/App.tsx
+++ b/FRONTEND/src/App.tsx
@@ -1,4 +1,4 @@
-import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom'
+import { BrowserRouter, Routes, Route, Navigate, Outlet } from 'react-router-dom'
 import LoginPage from './pages/LoginPage'
 import RegisterPage from './pages/RegisterPage'
 import LeaderboardPage from './pages/LeaderboardPage'
@@ -6,7 +6,7 @@ import StatsPage from './pages/StatsPage'
 import HistoryPage from './pages/HistoryPage'
 import GamePage from './pages/GamePage'
 import { useAuth } from './hooks/useAuth'
-import ProtectedRoute from './components/ProtectedRoute'
+import Navbar from './components/Navbar'
 
 const RootRedirect = () => {
   const { accessToken } = useAuth()
@@ -17,6 +17,19 @@ const RootRedirect = () => {
   )
 }
 
+const ProtectedLayout = () => {
+  const { accessToken } = useAuth()
+  if (!accessToken) return <Navigate to="/login" replace />
+  return (
+    <div className="min-h-screen bg-[#0e1116] text-[#e7ecef] text-left">
+      <Navbar />
+      <main className="py-6">
+        <Outlet />
+      </main>
+    </div>
+  )
+}
+
 const App = () => {
   return (
     <BrowserRouter>
@@ -24,7 +37,7 @@ const App = () => {
         <Route path="/" element={<RootRedirect />} />
         <Route path="/login" element={<LoginPage />} />
         <Route path="/register" element={<RegisterPage />} />
-        <Route element={<ProtectedRoute />}>
+        <Route element={<ProtectedLayout />}>
           <Route path="/leaderboard" element={<LeaderboardPage />} />
           <Route path="/stats" element={<StatsPage />} />
           <Route path="/history" element={<HistoryPage />} />

--- a/FRONTEND/src/components/Navbar.tsx
+++ b/FRONTEND/src/components/Navbar.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react'
 import { NavLink, useNavigate } from 'react-router-dom'
 import { useAuth } from '../hooks/useAuth'
 
@@ -11,15 +12,30 @@ const Brand = () => (
   </div>
 )
 
+const HamburgerIcon = () => (
+  <svg width="20" height="20" viewBox="0 0 20 20" fill="none" stroke="currentColor" strokeWidth="1.5">
+    <line x1="3" y1="5" x2="17" y2="5" />
+    <line x1="3" y1="10" x2="17" y2="10" />
+    <line x1="3" y1="15" x2="17" y2="15" />
+  </svg>
+)
+
+const CloseIcon = () => (
+  <svg width="20" height="20" viewBox="0 0 20 20" fill="none" stroke="currentColor" strokeWidth="1.5">
+    <line x1="4" y1="4" x2="16" y2="16" />
+    <line x1="16" y1="4" x2="4" y2="16" />
+  </svg>
+)
+
 const Navbar = () => {
   const { player, logout } = useAuth()
   const navigate = useNavigate()
+  const [open, setOpen] = useState(false)
 
   const handleLogout = async () => {
+    setOpen(false)
     await logout()
     navigate('/login')
-
-    
   }
 
   const linkClass = ({ isActive }: { isActive: boolean }) =>
@@ -31,12 +47,14 @@ const Navbar = () => {
     <header className="border-b border-[#2a313b] bg-[#0e1116]">
       <div className="mx-auto flex max-w-5xl items-center justify-between px-6 py-4">
         <Brand />
-        <nav className="flex items-center gap-7">
+
+        <nav className="hidden items-center gap-7 md:flex">
           <NavLink to="/leaderboard" className={linkClass}>Leaderboard</NavLink>
           <NavLink to="/stats" className={linkClass}>Stats</NavLink>
           <NavLink to="/history" className={linkClass}>History</NavLink>
         </nav>
-        <div className="flex items-center gap-5">
+
+        <div className="hidden items-center gap-5 md:flex">
           <span className="font-mono text-[11px] tracking-[1px] text-[#98a1ad]">
             {player?.username}
           </span>
@@ -47,7 +65,36 @@ const Navbar = () => {
             Logout
           </button>
         </div>
+
+        <button
+          onClick={() => setOpen(prev => !prev)}
+          className="text-[#98a1ad] transition-colors hover:text-[#e7ecef] md:hidden"
+          aria-label="Toggle menu"
+        >
+          {open ? <CloseIcon /> : <HamburgerIcon />}
+        </button>
       </div>
+
+      {open && (
+        <div className="border-t border-[#2a313b] px-6 pb-5 pt-4 md:hidden">
+          <nav className="flex flex-col gap-4">
+            <NavLink to="/leaderboard" className={linkClass} onClick={() => setOpen(false)}>Leaderboard</NavLink>
+            <NavLink to="/stats" className={linkClass} onClick={() => setOpen(false)}>Stats</NavLink>
+            <NavLink to="/history" className={linkClass} onClick={() => setOpen(false)}>History</NavLink>
+          </nav>
+          <div className="mt-5 flex items-center justify-between border-t border-[#2a313b] pt-4">
+            <span className="font-mono text-[11px] tracking-[1px] text-[#98a1ad]">
+              {player?.username}
+            </span>
+            <button
+              onClick={handleLogout}
+              className="font-mono text-[11px] tracking-[1.1px] uppercase text-[#98a1ad] transition-colors hover:text-[#ee6951]"
+            >
+              Logout
+            </button>
+          </div>
+        </div>
+      )}
     </header>
   )
 }

--- a/FRONTEND/src/components/Navbar.tsx
+++ b/FRONTEND/src/components/Navbar.tsx
@@ -1,0 +1,55 @@
+import { NavLink, useNavigate } from 'react-router-dom'
+import { useAuth } from '../hooks/useAuth'
+
+const Brand = () => (
+  <div className="flex items-center gap-3 font-mono text-[13px] font-bold tracking-[2.34px] text-[#e7ecef]">
+    <span className="relative grid size-[22px] shrink-0 place-items-center border border-[#e7ecef]">
+      <span className="size-2.5 border border-[#e7ecef]" />
+      <span className="absolute size-[5px] rounded-full bg-[#5ebc7b]" />
+    </span>
+    <span>WAR OF TANKS</span>
+  </div>
+)
+
+const Navbar = () => {
+  const { player, logout } = useAuth()
+  const navigate = useNavigate()
+
+  const handleLogout = async () => {
+    await logout()
+    navigate('/login')
+
+    
+  }
+
+  const linkClass = ({ isActive }: { isActive: boolean }) =>
+    `font-mono text-[11px] tracking-[1.1px] uppercase transition-colors ${
+      isActive ? 'text-[#e7ecef]' : 'text-[#98a1ad] hover:text-[#e7ecef]'
+    }`
+
+  return (
+    <header className="border-b border-[#2a313b] bg-[#0e1116]">
+      <div className="mx-auto flex max-w-5xl items-center justify-between px-6 py-4">
+        <Brand />
+        <nav className="flex items-center gap-7">
+          <NavLink to="/leaderboard" className={linkClass}>Leaderboard</NavLink>
+          <NavLink to="/stats" className={linkClass}>Stats</NavLink>
+          <NavLink to="/history" className={linkClass}>History</NavLink>
+        </nav>
+        <div className="flex items-center gap-5">
+          <span className="font-mono text-[11px] tracking-[1px] text-[#98a1ad]">
+            {player?.username}
+          </span>
+          <button
+            onClick={handleLogout}
+            className="font-mono text-[11px] tracking-[1.1px] uppercase text-[#98a1ad] transition-colors hover:text-[#ee6951]"
+          >
+            Logout
+          </button>
+        </div>
+      </div>
+    </header>
+  )
+}
+
+export default Navbar

--- a/FRONTEND/src/components/stats/StatCard.tsx
+++ b/FRONTEND/src/components/stats/StatCard.tsx
@@ -1,0 +1,22 @@
+interface StatCardProps {
+  label: string
+  value: string | number
+  accent?: boolean
+}
+
+const StatCard = ({ label, value, accent = false }: StatCardProps) => (
+  <div className="border border-[#2a313b] bg-[#11161d] px-5 py-5">
+    <p className="mb-3 font-mono text-[10.5px] tracking-[1.05px] uppercase text-[#98a1ad]">
+      {label}
+    </p>
+    <p
+      className={`font-mono text-[28px] font-bold leading-none tracking-tight ${
+        accent ? 'text-[#5dcbd1]' : 'text-[#e7ecef]'
+      }`}
+    >
+      {value}
+    </p>
+  </div>
+)
+
+export default StatCard

--- a/FRONTEND/src/components/stats/WinLossBar.tsx
+++ b/FRONTEND/src/components/stats/WinLossBar.tsx
@@ -1,0 +1,25 @@
+interface WinLossBarProps {
+  winRate: number
+}
+
+const WinLossBar = ({ winRate }: WinLossBarProps) => (
+  <div className="border border-[#2a313b] bg-[#11161d] px-5 py-5">
+    <p className="mb-4 font-mono text-[10.5px] tracking-[1.05px] uppercase text-[#98a1ad]">
+      Win / Loss ratio
+    </p>
+    <div className="h-2 overflow-hidden rounded-full bg-[#2a313b]">
+      {winRate > 0 && (
+        <div
+          className="h-full bg-[#5ebc7b] transition-all duration-500"
+          style={{ width: `${winRate}%` }}
+        />
+      )}
+    </div>
+    <div className="mt-2.5 flex justify-between font-mono text-[10.5px]">
+      <span className="text-[#5ebc7b]">{winRate}% wins</span>
+      <span className="text-[#ee6951]">{100 - winRate}% losses</span>
+    </div>
+  </div>
+)
+
+export default WinLossBar

--- a/FRONTEND/src/components/ui/ErrorBanner.tsx
+++ b/FRONTEND/src/components/ui/ErrorBanner.tsx
@@ -1,0 +1,11 @@
+interface ErrorBannerProps {
+  message: string
+}
+
+const ErrorBanner = ({ message }: ErrorBannerProps) => (
+  <div className="mb-6 border border-[#ee6951]/40 bg-[#ee6951]/10 px-4 py-3 text-sm text-[#ee6951]">
+    {message}
+  </div>
+)
+
+export default ErrorBanner

--- a/FRONTEND/src/components/ui/PageHeader.tsx
+++ b/FRONTEND/src/components/ui/PageHeader.tsx
@@ -1,0 +1,23 @@
+import type { ReactNode } from 'react'
+
+interface PageHeaderProps {
+  section: string
+  title: string
+  action?: ReactNode
+}
+
+const PageHeader = ({ section, title, action }: PageHeaderProps) => (
+  <div className="mb-8 flex items-end justify-between border-b border-[#2a313b] pb-5">
+    <div>
+      <p className="mb-1 font-mono text-[10.5px] tracking-[1.05px] uppercase text-[#98a1ad]">
+        {section}
+      </p>
+      <p className="text-[22px] font-semibold leading-tight tracking-tight text-[#e7ecef]">
+        {title}
+      </p>
+    </div>
+    {action && <div>{action}</div>}
+  </div>
+)
+
+export default PageHeader

--- a/FRONTEND/src/components/ui/SkeletonRows.tsx
+++ b/FRONTEND/src/components/ui/SkeletonRows.tsx
@@ -1,0 +1,14 @@
+interface SkeletonRowsProps {
+  count?: number
+  height?: string
+}
+
+const SkeletonRows = ({ count = 6, height = 'h-14' }: SkeletonRowsProps) => (
+  <div className="space-y-px">
+    {Array.from({ length: count }).map((_, i) => (
+      <div key={i} className={`${height} animate-pulse bg-[#11161d]`} />
+    ))}
+  </div>
+)
+
+export default SkeletonRows

--- a/FRONTEND/src/context/AuthProvider.tsx
+++ b/FRONTEND/src/context/AuthProvider.tsx
@@ -29,10 +29,12 @@ const normalizePlayer = (player: LoginResponsePlayer): Player => ({
   id: player.id,
   username: player.username,
   email: player.email ?? '',
-  totalMatches: player.stats?.totalMatches ?? player.totalMatches ?? 0,
-  wins: player.stats?.wins ?? player.wins ?? 0,
-  losses: player.stats?.losses ?? player.losses ?? 0,
-  totalScore: player.stats?.totalScore ?? player.totalScore ?? 0,
+  stats: {
+    totalMatches: player.stats?.totalMatches ?? player.totalMatches ?? 0,
+    wins: player.stats?.wins ?? player.wins ?? 0,
+    losses: player.stats?.losses ?? player.losses ?? 0,
+    totalScore: player.stats?.totalScore ?? player.totalScore ?? 0,
+  },
 })
 
 export const AuthProvider = ({ children }: { children: ReactNode }) => {

--- a/FRONTEND/src/index.css
+++ b/FRONTEND/src/index.css
@@ -78,25 +78,6 @@ h2 {
   font-weight: 500;
   color: var(--text-h);
 }
-
-h1 {
-  font-size: 56px;
-  letter-spacing: -1.68px;
-  margin: 32px 0;
-  @media (max-width: 1024px) {
-    font-size: 36px;
-    margin: 20px 0;
-  }
-}
-h2 {
-  font-size: 24px;
-  line-height: 118%;
-  letter-spacing: -0.24px;
-  margin: 0 0 8px;
-  @media (max-width: 1024px) {
-    font-size: 20px;
-  }
-}
 p {
   margin: 0;
 }

--- a/FRONTEND/src/pages/HistoryPage.tsx
+++ b/FRONTEND/src/pages/HistoryPage.tsx
@@ -62,7 +62,8 @@ const HistoryPage = () => {
         </p>
       ) : (
         <>
-          <div className="border border-[#2a313b]">
+          <div className="overflow-x-auto border border-[#2a313b]">
+            <div className="min-w-[480px]">
             <div className="grid grid-cols-4 border-b border-[#2a313b] px-5 py-3">
               {TABLE_HEADERS.map(h => (
                 <span
@@ -106,6 +107,7 @@ const HistoryPage = () => {
             })}
 
             {loading && <SkeletonRows count={3} height="h-[60px]" />}
+            </div>
           </div>
 
           {!loading && hasMore && (

--- a/FRONTEND/src/pages/HistoryPage.tsx
+++ b/FRONTEND/src/pages/HistoryPage.tsx
@@ -1,7 +1,125 @@
-import React from 'react'
+import { useEffect, useState } from 'react'
+import { client } from '../api/client'
+import type { Match } from '../types'
+import ErrorBanner from '../components/ui/ErrorBanner'
+import PageHeader from '../components/ui/PageHeader'
+import SkeletonRows from '../components/ui/SkeletonRows'
 
-const HistoryPage: React.FC = () => {
-  return <div>HistoryPage</div>
+const PAGE_SIZE = 10
+
+const formatDate = (iso: string) =>
+  new Date(iso).toLocaleDateString('fr-FR', {
+    day: '2-digit',
+    month: '2-digit',
+    year: 'numeric',
+  })
+
+const formatDuration = (secs: number) => {
+  const m = Math.floor(secs / 60)
+  const s = Math.round(secs % 60)
+  return `${m}:${s.toString().padStart(2, '0')}`
+}
+
+const TABLE_HEADERS = ['Result', 'Score', 'Duration', 'Date']
+
+const HistoryPage = () => {
+  const [matches, setMatches] = useState<Match[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [offset, setOffset] = useState(0)
+  const [hasMore, setHasMore] = useState(true)
+
+  const fetchMatches = async (currentOffset: number, reset: boolean) => {
+    setLoading(true)
+    setError(null)
+    try {
+      const { data } = await client.get<Match[]>('/api/v1/matches', {
+        params: { limit: PAGE_SIZE, offset: currentOffset },
+      })
+      setMatches(prev => (reset ? data : [...prev, ...data]))
+      setHasMore(data.length === PAGE_SIZE)
+      setOffset(currentOffset + data.length)
+    } catch {
+      setError('Could not load match history. Please try again.')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  useEffect(() => {
+    fetchMatches(0, true)
+  }, [])
+
+  return (
+    <div className="mx-auto max-w-5xl px-6 py-10">
+      <PageHeader section="Personal" title="Match History" />
+
+      {error && <ErrorBanner message={error} />}
+
+      {!loading && matches.length === 0 ? (
+        <p className="py-16 text-center font-mono text-sm text-[#98a1ad]">
+          No matches played yet.
+        </p>
+      ) : (
+        <>
+          <div className="border border-[#2a313b]">
+            <div className="grid grid-cols-4 border-b border-[#2a313b] px-5 py-3">
+              {TABLE_HEADERS.map(h => (
+                <span
+                  key={h}
+                  className="font-mono text-[10.5px] tracking-[1.05px] uppercase text-[#98a1ad]"
+                >
+                  {h}
+                </span>
+              ))}
+            </div>
+
+            {matches.map((match, i) => {
+              const won = match.winnerTeam === 1
+              return (
+                <div
+                  key={match.id}
+                  className={`grid grid-cols-4 items-center px-5 py-4 transition-colors hover:bg-[#11161d] ${
+                    i < matches.length - 1 ? 'border-b border-[#2a313b]/60' : ''
+                  }`}
+                >
+                  <span
+                    className={`font-mono text-xs font-bold tracking-[1px] uppercase ${
+                      won ? 'text-[#5ebc7b]' : 'text-[#ee6951]'
+                    }`}
+                  >
+                    {won ? 'Victory' : 'Defeat'}
+                  </span>
+                  <span className="font-mono text-sm text-[#e7ecef]">
+                    {match.playerScore}
+                    <span className="mx-1.5 text-[#98a1ad]">—</span>
+                    {match.aiScore}
+                  </span>
+                  <span className="font-mono text-sm text-[#98a1ad]">
+                    {formatDuration(match.duration)}
+                  </span>
+                  <span className="font-mono text-xs text-[#98a1ad]">
+                    {formatDate(match.createdAt)}
+                  </span>
+                </div>
+              )
+            })}
+
+            {loading && <SkeletonRows count={3} height="h-[60px]" />}
+          </div>
+
+          {!loading && hasMore && (
+            <button
+              onClick={() => fetchMatches(offset, false)}
+              className="mt-4 w-full border border-[#2a313b] py-3 font-mono text-[11px] tracking-[1.1px] uppercase text-[#98a1ad] transition-colors hover:border-[#5dcbd1] hover:text-[#5dcbd1]"
+            >
+              Load more
+            </button>
+          )}
+        </>
+      )}
+    </div>
+  )
 }
 
 export default HistoryPage

--- a/FRONTEND/src/pages/LeaderboardPage.tsx
+++ b/FRONTEND/src/pages/LeaderboardPage.tsx
@@ -54,7 +54,8 @@ const LeaderboardPage = () => {
           No players yet.
         </p>
       ) : (
-        <table className="w-full border-collapse">
+        <div className="overflow-x-auto">
+        <table className="w-full min-w-[500px] border-collapse">
           <thead>
             <tr className="border-b border-[#2a313b]">
               {['#', 'Player', 'Score', 'W', 'L', 'Win %'].map((h, i) => (
@@ -111,6 +112,7 @@ const LeaderboardPage = () => {
             })}
           </tbody>
         </table>
+        </div>
       )}
     </div>
   )

--- a/FRONTEND/src/pages/LeaderboardPage.tsx
+++ b/FRONTEND/src/pages/LeaderboardPage.tsx
@@ -1,7 +1,119 @@
-import React from 'react'
+import { useEffect, useState } from 'react'
+import { client } from '../api/client'
+import { useAuth } from '../hooks/useAuth'
+import type { Player } from '../types'
+import ErrorBanner from '../components/ui/ErrorBanner'
+import PageHeader from '../components/ui/PageHeader'
+import SkeletonRows from '../components/ui/SkeletonRows'
 
-const LeaderboardPage: React.FC = () => {
-  return <div>LeaderboardPage</div>
+const LeaderboardPage = () => {
+  const { player: me } = useAuth()
+  const [players, setPlayers] = useState<Player[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  const fetchPlayers = async () => {
+    setLoading(true)
+    setError(null)
+    try {
+      const { data } = await client.get<Player[]>('/api/v1/players')
+      setPlayers(data)
+    } catch {
+      setError('Could not load leaderboard. Please try again.')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  useEffect(() => {
+    fetchPlayers()
+  }, [])
+
+  return (
+    <div className="mx-auto max-w-5xl px-6 py-10">
+      <PageHeader
+        section="Rankings"
+        title="Leaderboard"
+        action={
+          <button
+            onClick={fetchPlayers}
+            disabled={loading}
+            className="font-mono text-[11px] tracking-[1.1px] uppercase text-[#98a1ad] transition-colors hover:text-[#5dcbd1] disabled:opacity-40"
+          >
+            {loading ? 'Loading…' : 'Refresh'}
+          </button>
+        }
+      />
+
+      {error && <ErrorBanner message={error} />}
+
+      {loading ? (
+        <SkeletonRows count={6} />
+      ) : players.length === 0 ? (
+        <p className="py-16 text-center font-mono text-sm text-[#98a1ad]">
+          No players yet.
+        </p>
+      ) : (
+        <table className="w-full border-collapse">
+          <thead>
+            <tr className="border-b border-[#2a313b]">
+              {['#', 'Player', 'Score', 'W', 'L', 'Win %'].map((h, i) => (
+                <th
+                  key={h}
+                  className={`pb-3 font-mono text-[10.5px] tracking-[1.05px] uppercase text-[#98a1ad] ${
+                    i === 0 ? 'w-12 text-left' : i === 1 ? 'text-left' : 'text-right'
+                  }`}
+                >
+                  {h}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {players.map((p, i) => {
+              const isMe = p.id === me?.id
+              const winRate =
+                p.stats.totalMatches > 0
+                  ? Math.round((p.stats.wins / p.stats.totalMatches) * 100)
+                  : 0
+              return (
+                <tr
+                  key={p.id}
+                  className={`border-b border-[#2a313b]/60 transition-colors ${
+                    isMe ? 'bg-[#5dcbd1]/[0.06]' : 'hover:bg-[#11161d]'
+                  }`}
+                >
+                  <td className="py-4 font-mono text-xs text-[#98a1ad]">
+                    {String(i + 1).padStart(2, '0')}
+                  </td>
+                  <td className="py-4 text-sm text-[#e7ecef]">
+                    {p.username}
+                    {isMe && (
+                      <span className="ml-2 font-mono text-[10px] tracking-[0.5px] text-[#5dcbd1]">
+                        you
+                      </span>
+                    )}
+                  </td>
+                  <td className="py-4 text-right font-mono text-sm text-[#e7ecef]">
+                    {p.stats.totalScore}
+                  </td>
+                  <td className="py-4 text-right font-mono text-sm text-[#5ebc7b]">
+                    {p.stats.wins}
+                  </td>
+                  <td className="py-4 text-right font-mono text-sm text-[#ee6951]">
+                    {p.stats.losses}
+                  </td>
+                  <td className="py-4 text-right font-mono text-sm text-[#98a1ad]">
+                    {winRate}%
+                  </td>
+                </tr>
+              )
+            })}
+          </tbody>
+        </table>
+      )}
+    </div>
+  )
 }
 
 export default LeaderboardPage

--- a/FRONTEND/src/pages/StatsPage.tsx
+++ b/FRONTEND/src/pages/StatsPage.tsx
@@ -1,7 +1,63 @@
-import React from 'react'
+import { useEffect, useState } from 'react'
+import { client } from '../api/client'
+import type { Player } from '../types'
+import ErrorBanner from '../components/ui/ErrorBanner'
+import PageHeader from '../components/ui/PageHeader'
+import SkeletonRows from '../components/ui/SkeletonRows'
+import StatCard from '../components/stats/StatCard'
+import WinLossBar from '../components/stats/WinLossBar'
 
-const StatsPage: React.FC = () => {
-  return <div>StatsPage</div>
+const StatsPage = () => {
+  const [player, setPlayer] = useState<Player | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    client
+      .get<Player>('/api/v1/players/me')
+      .then(({ data }) => setPlayer(data))
+      .catch(() => setError('Could not load your stats. Please try again.'))
+      .finally(() => setLoading(false))
+  }, [])
+
+  if (loading) {
+    return (
+      <div className="mx-auto max-w-5xl px-6 py-10">
+        <div className="mb-8 h-7 w-48 animate-pulse bg-[#11161d]" />
+        <SkeletonRows count={5} height="h-28" />
+      </div>
+    )
+  }
+
+  if (error) {
+    return (
+      <div className="mx-auto max-w-5xl px-6 py-10">
+        <ErrorBanner message={error} />
+      </div>
+    )
+  }
+
+  if (!player) return null
+
+  const { stats } = player
+  const winRate =
+    stats.totalMatches > 0 ? Math.round((stats.wins / stats.totalMatches) * 100) : 0
+
+  return (
+    <div className="mx-auto max-w-5xl px-6 py-10">
+      <PageHeader section="Personal" title={player.username} />
+
+      <div className="mb-8 grid grid-cols-2 gap-px border border-[#2a313b] lg:grid-cols-3">
+        <StatCard label="Total Score" value={stats.totalScore} accent />
+        <StatCard label="Matches" value={stats.totalMatches} />
+        <StatCard label="Win Rate" value={`${winRate}%`} />
+        <StatCard label="Wins" value={stats.wins} />
+        <StatCard label="Losses" value={stats.losses} />
+      </div>
+
+      {stats.totalMatches > 0 && <WinLossBar winRate={winRate} />}
+    </div>
+  )
 }
 
 export default StatsPage

--- a/FRONTEND/src/types/index.ts
+++ b/FRONTEND/src/types/index.ts
@@ -1,25 +1,32 @@
+interface PlayerStats {
+  wins: number
+  losses: number
+  totalMatches: number
+  totalScore: number
+}
+
 interface Player {
   id: string
   username: string
   email: string
-  totalMatches: number
-  wins: number
-  losses: number
-  totalScore: number
+  stats: PlayerStats
+  createdAt?: string
+  updatedAt?: string
 }
 
 interface Match {
   id: string
   playerId: string
-  teamAScore: number
-  teamBScore: number
-  playerWon: boolean
-  durationSecs: number
-  playedAt: string
+  playerSnapshot: { username: string }
+  winnerTeam: number
+  playerScore: number
+  aiScore: number
+  duration: number
+  createdAt: string
 }
 
 interface AuthTokens {
   accessToken: string
 }
 
-export type { Player, Match, AuthTokens }
+export type { Player, PlayerStats, Match, AuthTokens }

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -96,38 +96,31 @@ npm run dev
 - ✅ [#22](https://github.com/oussema-fatnassi/WarOfTanks/issues/22) AI - Tank Behaviour Trees (Specializations) — 3 AI roles (Captor, Attacker, Defender) each with a priority-ordered BT; TankBlackboard data snapshot; VisionSystem stub; GameManager tank registry; partial class TankAI split across 5 files; Enemy.prefab updated
 - ✅ [#30](https://github.com/oussema-fatnassi/WarOfTanks/issues/30) Auth Pages (Register + Login) — two-column auth layout, login/register pages with form validation, AuthContext + AuthProvider + useAuth hook, Axios refresh interceptor guard, CORS middleware, email required at registration
 - ✅ [#28](https://github.com/oussema-fatnassi/WarOfTanks/issues/28) Backend Unit Tests & CI Integration — comprehensive handler tests (auth, player, match) against real MongoDB; CI updated to MongoDB replica set for transaction support; `go test -race -coverprofile`; `TestSaveMatch` covers win/loss stats update atomically
+- ✅ [#19](https://github.com/oussema-fatnassi/WarOfTanks/issues/19) Detection System - Field of View — VisionSystem with configurable range + angle, target layer filtering, line-of-sight raycasts, Gizmo debug arcs
+- ✅ [#23](https://github.com/oussema-fatnassi/WarOfTanks/issues/23) Commander AI — strategic AI commander that coordinates AI tanks, assigns roles, and adapts tactics based on game state
+- ✅ [#31](https://github.com/oussema-fatnassi/WarOfTanks/issues/31) Leaderboard, Stats & Match History Pages — Leaderboard table (ranked by totalScore, current player highlighted), personal stats cards with win/loss bar, match history with pagination, responsive mobile layout with hamburger menu, loading skeletons and error handling
 
 ## In Progress / Remaining
 
-### Sprint 3 — Navigation & Backend Foundation (Apr 20 – Apr 26)
+### Sprint 3 — Navigation & Backend Foundation
 
-| #                                                               | Title                                                 | Owner   | Priority | Status      |
-| --------------------------------------------------------------- | ----------------------------------------------------- | ------- | -------- | ----------- |
-| [#14](https://github.com/oussema-fatnassi/WarOfTanks/issues/14) | Navigation - Dijkstra | Oroitz | Medium | Not started |
+| #                                                               | Title                 | Owner  | Priority | Status      |
+| --------------------------------------------------------------- | --------------------- | ------ | -------- | ----------- |
+| [#14](https://github.com/oussema-fatnassi/WarOfTanks/issues/14) | Navigation - Dijkstra | Oroitz | Medium   | Not started |
 
-### Sprint 4 — AI Systems & Backend Routes (May 18 – May 24)
-
-| #                                                               | Title                                       | Owner   | Priority | Status      |
-| --------------------------------------------------------------- | ------------------------------------------- | ------- | -------- | ----------- |
-| [#15](https://github.com/oussema-fatnassi/WarOfTanks/issues/15) | Navigation - Flow Field                     | Kamelia | Medium   | ✅ Done  |
-| [#19](https://github.com/oussema-fatnassi/WarOfTanks/issues/19) | Detection System - Field of View            | Oroitz  | High     | Not started |
-| [#20](https://github.com/oussema-fatnassi/WarOfTanks/issues/20) | Fog of War (WebGL-Compatible)               | Oroitz  | High     | Not started |
-| [#22](https://github.com/oussema-fatnassi/WarOfTanks/issues/22) | AI - Tank Behaviour Trees (Specializations) | Oroitz  | Critical | Not started |
-| [#27](https://github.com/oussema-fatnassi/WarOfTanks/issues/27) | Player & Match Routes                       | Kamelia | High     | ✅ Done  |
-| [#28](https://github.com/oussema-fatnassi/WarOfTanks/issues/28) | Backend Unit Tests & CI Integration         | Kamelia | High     | ✅ Done  |
-
-### Sprint 5 — Integration & Delivery (May 25 – May 31)
+### Sprint 5 — Integration & Delivery
 
 | #                                                               | Title                                                    | Owner   | Priority | Status      |
 | --------------------------------------------------------------- | -------------------------------------------------------- | ------- | -------- | ----------- |
 | [#7](https://github.com/oussema-fatnassi/WarOfTanks/issues/7)   | GitHub Actions - WebGL Build                             | Oussema | Medium   | Not started |
-| [#23](https://github.com/oussema-fatnassi/WarOfTanks/issues/23) | Commander AI                                             | Oussema | High     | Not started |
-| [#31](https://github.com/oussema-fatnassi/WarOfTanks/issues/31) | Leaderboard, Stats & Match History Pages                 | Oussema | High     | Not started |
+| [#20](https://github.com/oussema-fatnassi/WarOfTanks/issues/20) | Fog of War (WebGL-Compatible)                            | Oroitz  | High     | Not started |
 | [#32](https://github.com/oussema-fatnassi/WarOfTanks/issues/32) | WebGL Game Embed                                         | Oussema | High     | Not started |
 | [#33](https://github.com/oussema-fatnassi/WarOfTanks/issues/33) | Docker Compose - Full Stack                              | Kamelia | High     | Not started |
 | [#34](https://github.com/oussema-fatnassi/WarOfTanks/issues/34) | Deploy Backend to Render                                 | Kamelia | Medium   | Not started |
 | [#36](https://github.com/oussema-fatnassi/WarOfTanks/issues/36) | Presentation Slides                                      | All     | High     | Not started |
 | [#47](https://github.com/oussema-fatnassi/WarOfTanks/issues/47) | UI Mockups - Figma (Zoning, Wireframe, Hi-fi, Prototype) | Oussema | High     | Not started |
+| [#66](https://github.com/oussema-fatnassi/WarOfTanks/issues/66) | Refactor: GameManager SOLID improvements                 | Oussema | Low      | Not started |
+| [#73](https://github.com/oussema-fatnassi/WarOfTanks/issues/73) | Unity — Post Match Result to Backend on Game Over        | Oroitz  | High     | Not started |
 
 ## Known Bugs & Issues
 


### PR DESCRIPTION
## Summary
- Implement three protected pages: **Leaderboard** (`/leaderboard`), **Personal Stats** (`/stats`), and **Match History** (`/history`)
- Add reusable UI components: `Navbar`, `PageHeader`, `ErrorBanner`, `SkeletonRows`, `StatCard`, `WinLossBar`
- Add responsive mobile layout with hamburger menu on Navbar and horizontal table scroll on small screens
- Update READMEs with current project status

## Pages

| Page | Route | API |
|---|---|---|
| Leaderboard | `/leaderboard` | `GET /api/v1/players` — ranked by totalScore DESC |
| Personal Stats | `/stats` | `GET /api/v1/players/me` — cards with wins, losses, win rate, score |
| Match History | `/history` | `GET /api/v1/matches` — paginated with Load more, Victory/Defeat display |

## DoD Checklist — Issue #31
- [x] Leaderboard displays all players ranked correctly
- [x] Current player highlighted in leaderboard
- [x] Personal stats page shows correct data from `/players/me`
- [x] Match history shows player's own matches with correct Win/Loss display
- [x] Pagination works on match history
- [x] All pages handle loading state (skeleton or spinner)
- [x] All pages handle API error state
- [x] All pages are responsive (mobile hamburger menu + horizontal table scroll)
- [x] Naming convention check passed on all component files

## Test plan
- [x] Login and verify redirect to `/leaderboard`
- [x] Check leaderboard table shows players sorted by score, current player highlighted
- [x] Navigate to `/stats` and verify personal stats cards display correctly
- [x] Navigate to `/history` and verify match list with Victory/Defeat colors
- [x] Click "Load more" on history page to test pagination
- [x] Resize browser below 768px — hamburger menu should appear, desktop nav should hide
- [x] Click hamburger — mobile menu opens with links; clicking a link closes it
- [x] Verify tables scroll horizontally on small screens without layout break

Closes #31