### PR TITLE
feat(docker): Docker Compose full stack setup

### DIFF
--- a/BACKEND/middleware/cors.go
+++ b/BACKEND/middleware/cors.go
@@ -10,6 +10,7 @@ import (
 func CORS(frontendOrigin string) gin.HandlerFunc {
 	allowedOrigins := map[string]bool{
 		frontendOrigin:          true,
+		"http://localhost:5173": true,
 		"http://127.0.0.1:5173": true,
 	}
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,8 @@
 services:
   mongo:
     image: mongo:7
+    ports:
+      - "27017:27017"
     volumes:
       - mongodb_data:/data/db
     networks:
@@ -23,7 +25,7 @@ services:
         condition: service_healthy
     restart: unless-stopped
     healthcheck:
-      test: ["CMD", "wget", "--spider", "-q", "http://localhost:8080/health"]
+      test: ["CMD", "wget", "--spider", "-q", "http://localhost:8080/api/v1/health"]
       interval: 10s
       timeout: 5s
       retries: 5

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "WarOfTanks",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}


### PR DESCRIPTION
## Summary
- Set up Docker Compose with MongoDB, backend, and frontend services
- Fix backend healthcheck URL to use `/api/v1/health` instead of `/health`
- Expose MongoDB port 27017 for local development tools (Compass)
- Add `http://localhost:5173` to CORS allowed origins for local dev

## Test plan
- [x] Run `docker-compose up --build` and verify all 3 services start healthy
- [x] Verify frontend is accessible on `http://localhost:3000`
- [x] Verify backend responds on `http://localhost:8080/api/v1/health`
- [x] Verify MongoDB Compass can connect on `127.0.0.1:27017`
- [x] Test register/login flow from frontend to backend
