### PR TITLE
[#34] Deploy Backend to Render

### DIFF
--- a/BACKEND/.env.example
+++ b/BACKEND/.env.example
@@ -1,6 +1,23 @@
+# --- Database ---
+# Local (docker-compose): mongodb://mongo:27017
+# Production (Render): MongoDB Atlas SRV string, e.g.
+#   mongodb+srv://USER:PASS@cluster0.xxxxx.mongodb.net/?retryWrites=true&w=majority
 MONGODB_URI=mongodb://mongo:27017
 MONGODB_DB_NAME=waroftanks
+
+# --- Auth secrets (use long random strings in production) ---
 JWT_SECRET=change-me-to-a-random-32-char-string
 JWT_REFRESH_SECRET=change-me-to-another-random-string
+
+# --- Server ---
+# Local default is 8080. On Render, leave this UNSET — Render injects PORT.
 PORT=8080
+# Use production on Render so auth cookies are Secure and SameSite=None.
+APP_ENV=development
+
+# --- CORS ---
+# Comma-separated list of allowed browser origins (no trailing slash).
+# Production example: https://war-of-tanks.vercel.app
+# FRONTEND_ORIGIN is kept as a fallback for older configs.
+ALLOWED_ORIGINS=http://localhost:5173,http://localhost:3000
 FRONTEND_ORIGIN=http://localhost:3000

--- a/BACKEND/cmd/main.go
+++ b/BACKEND/cmd/main.go
@@ -55,7 +55,12 @@ func main() {
 
 	// Initialize Gin router
 	r := gin.Default()
-	r.Use(middleware.CORS(cfg.FrontendOrigin))
+	r.Use(middleware.CORS(cfg.AllowedOrigins))
+
+	// Root health check (used by Render's health check and uptime probes).
+	r.GET("/health", func(c *gin.Context) {
+		c.JSON(200, gin.H{"status": "ok"})
+	})
 
 	// Route groups
 	api := r.Group("/api/v1")

--- a/BACKEND/config/config.go
+++ b/BACKEND/config/config.go
@@ -15,6 +15,7 @@ type Config struct {
 	JWTRefreshSecret string
 	Port             string
 	FrontendOrigin   string
+	AllowedOrigins   string
 }
 
 // Load reads environment variables from .env file and returns a Config.
@@ -30,10 +31,24 @@ func Load() *Config {
 		FrontendOrigin:   os.Getenv("FRONTEND_ORIGIN"),
 	}
 
-	if cfg.MongoURI == "" || cfg.JWTSecret == "" || cfg.MongoDBName == "" {
+	if cfg.MongoURI == "" || cfg.MongoDBName == "" || cfg.JWTSecret == "" || cfg.JWTRefreshSecret == "" {
 		log.Fatal("❌ Missing required environment variables")
 	}
 
+	// Render injects PORT automatically; default for local runs.
+	if cfg.Port == "" {
+		cfg.Port = "8080"
+	}
+
+	// CORS allow-list. Prefer ALLOWED_ORIGINS (comma-separated, set per environment
+	// in Render), fall back to FRONTEND_ORIGIN, then to local dev defaults.
+	cfg.AllowedOrigins = os.Getenv("ALLOWED_ORIGINS")
+	if cfg.AllowedOrigins == "" {
+		cfg.AllowedOrigins = cfg.FrontendOrigin
+	}
+	if cfg.AllowedOrigins == "" {
+		cfg.AllowedOrigins = "http://localhost:5173,http://localhost:3000"
+	}
 	if cfg.FrontendOrigin == "" {
 		cfg.FrontendOrigin = "http://localhost:5173"
 	}

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -1,0 +1,92 @@
+# Deployment — Backend on Render, Frontend on Vercel
+
+Architecture: **Vercel** serves the React/Vite frontend (static) → calls the
+**Render** Go API over HTTPS → which talks to **MongoDB Atlas**.
+
+```
+Browser ──> Vercel (frontend)  ──HTTPS──>  Render (Go backend)  ──>  MongoDB Atlas
+```
+
+The two services are wired by two env vars:
+- Frontend `VITE_API_URL`  → the Render backend URL
+- Backend `ALLOWED_ORIGINS` → the Vercel frontend URL (CORS)
+
+---
+
+## 1. MongoDB Atlas (free M0 cluster)
+
+1. Create an account at https://cloud.mongodb.com → create a free **M0** cluster.
+2. **Database Access** → add a user (username + password).
+3. **Network Access** → add IP `0.0.0.0/0` (Render uses dynamic IPs).
+4. **Connect → Drivers** → copy the SRV string:
+   `mongodb+srv://USER:PASS@cluster0.xxxxx.mongodb.net/?retryWrites=true&w=majority`
+
+If the password contains reserved URL characters (`@`, `:`, `/`, `%`, etc.),
+percent-encode it before putting it in the connection string.
+
+---
+
+## 2. Backend on Render
+
+This repo includes [`render.yaml`](./render.yaml) (a Blueprint), so most config is automatic.
+
+1. Merge the deployment work into `dev`, then open and merge a PR from `dev` to
+   `main`. The Blueprint intentionally deploys the production `main` branch.
+2. https://render.com → **New → Blueprint** → connect this GitHub repo and use
+   `render.yaml` from `main`.
+3. Render reads `render.yaml` and proposes the `waroftanks-backend` Docker service.
+4. Set the values marked `sync: false` in the dashboard:
+   | Key | Value |
+   |---|---|
+   | `MONGODB_URI` | the Atlas SRV string from step 1 |
+   | `ALLOWED_ORIGINS` | your Vercel URL (update it after the frontend deploy), e.g. `https://war-of-tanks.vercel.app` |
+
+   (`MONGODB_DB_NAME=waroftanks` and `APP_ENV=production` are already in the
+   Blueprint. Render generates both JWT secrets. **Do not set `PORT`** — Render
+   injects it.)
+5. Deploy. Commits merged into `main` deploy after the branch checks pass.
+6. Verify: `curl https://<your-app>.onrender.com/health` → `{"status":"ok"}`.
+
+> Note: Render free instances sleep after ~15 min idle; the first request then takes ~30–50s to wake.
+
+---
+
+## 3. Frontend on Vercel
+
+This repo includes [`FRONTEND/vercel.json`](./FRONTEND/vercel.json) (Vite preset + SPA rewrites).
+
+1. https://vercel.com → **Add New → Project** → import this repo.
+2. **Root Directory** → `FRONTEND`.
+3. Framework auto-detects **Vite** (build `npm run build`, output `dist`).
+4. **Environment Variables** → add:
+   | Key | Value |
+   |---|---|
+   | `VITE_API_URL` | your Render URL, e.g. `https://waroftanks-backend.onrender.com` |
+5. Deploy → you get a URL like `https://war-of-tanks.vercel.app`.
+
+---
+
+## 4. Wire them together (important)
+
+1. Copy the Vercel URL → set it as `ALLOWED_ORIGINS` on Render → redeploy backend.
+   (Multiple origins allowed, comma-separated — include the Vercel preview domain too if needed.)
+2. Confirm `VITE_API_URL` on Vercel points at the Render URL.
+3. Test end-to-end: open the Vercel site, register/login — no CORS errors, requests hit Render.
+
+---
+
+## 5. Update the README
+
+After deploy, record the public URLs in `ReadMe.md`:
+- API: `https://<your-app>.onrender.com`
+- App: `https://<your-app>.vercel.app`
+
+## Checklist (issue #34)
+- [ ] Atlas M0 cluster created, `0.0.0.0/0` allowed
+- [ ] Backend deployed on Render via Blueprint, `/health` returns 200
+- [ ] All secrets set as Render env vars (none in code)
+- [ ] Auto-deploy from `main` after CI checks enabled
+- [ ] `ALLOWED_ORIGINS` set to the Vercel URL (CORS)
+- [ ] Frontend deployed on Vercel with `VITE_API_URL` → Render
+- [ ] End-to-end login works from the Vercel site
+- [ ] Public URLs documented in README

--- a/FRONTEND/.env.example
+++ b/FRONTEND/.env.example
@@ -1,1 +1,5 @@
+# Backend API base URL (no trailing slash; request paths add /api/v1).
+# Local:      http://localhost:8080
+# Production: your Render backend URL, e.g. https://waroftanks-backend.onrender.com
+# On Vercel, set this as a Project Environment Variable (do not commit prod URL).
 VITE_API_URL=http://localhost:8080

--- a/FRONTEND/vercel.json
+++ b/FRONTEND/vercel.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "framework": "vite",
+  "buildCommand": "npm run build",
+  "outputDirectory": "dist",
+  "rewrites": [{ "source": "/(.*)", "destination": "/index.html" }]
+}

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,38 @@
+# Render Blueprint — deploys the Go backend as a Docker web service.
+# Docs: https://render.com/docs/blueprint-spec
+#
+# Usage: in Render → New → Blueprint → pick this repo. Render reads this file.
+# Values marked sync: false are NOT stored in git — set them in the Render dashboard.
+services:
+  - type: web
+    name: waroftanks-backend
+    runtime: docker
+    rootDir: BACKEND
+    # Render resolves these paths from the repository root, not rootDir.
+    dockerfilePath: ./BACKEND/Dockerfile
+    dockerContext: ./BACKEND
+    plan: free
+    region: frankfurt
+    # Production deploys from main after dev is promoted through a PR.
+    branch: main
+    autoDeployTrigger: checksPass
+    healthCheckPath: /health
+    envVars:
+      # Atlas SRV connection string — set in dashboard (secret)
+      - key: MONGODB_URI
+        sync: false
+      - key: MONGODB_DB_NAME
+        value: waroftanks
+      # Render generates and retains strong secrets for the service.
+      - key: JWT_SECRET
+        generateValue: true
+      - key: JWT_REFRESH_SECRET
+        generateValue: true
+      # Enables Secure + SameSite=None on the cross-site refresh cookie.
+      - key: APP_ENV
+        value: production
+      # Comma-separated Vercel/frontend origins — set in dashboard
+      # e.g. https://war-of-tanks.vercel.app
+      - key: ALLOWED_ORIGINS
+        sync: false
+      # NOTE: do NOT set PORT — Render injects it and the app reads it.


### PR DESCRIPTION
## Summary
- Adds a Render Blueprint (`render.yaml`) to deploy the Go backend as a Docker web service, with secrets kept out of git.
- Adds a root `GET /health` endpoint for Render's health check / uptime probes.
- Generalizes CORS to a comma-separated `ALLOWED_ORIGINS` allow-list (Render-set), with `FRONTEND_ORIGIN` and local-dev defaults as fallbacks.
- Hardens config: requires `JWT_REFRESH_SECRET`, defaults `PORT` (Render injects it in prod).
- Adds frontend Vercel config (`vercel.json`, SPA rewrites) and a full `DEPLOYMENT.md` guide (Render backend + Atlas + Vercel frontend).

## Issue
Closes #34

## Changes
- `render.yaml` — Render Blueprint: Docker web service, `rootDir BACKEND`, `healthCheckPath /health`, auto-deploy from `main` on `checksPass`; `MONGODB_URI`/`ALLOWED_ORIGINS` as dashboard secrets (`sync: false`), JWT secrets via `generateValue: true`.
- `BACKEND/config/config.go` — adds `AllowedOrigins` with fallback chain; enforces `JWTRefreshSecret`; defaults `PORT=8080`.
- `BACKEND/cmd/main.go` — root `/health` endpoint; CORS now uses `cfg.AllowedOrigins`.
- `BACKEND/.env.example` — documents Atlas URI, `ALLOWED_ORIGINS`, `APP_ENV`, PORT-on-Render guidance (placeholders only).
- `FRONTEND/.env.example` — `VITE_API_URL` (local + Render prod guidance).
- `FRONTEND/vercel.json` — Vite framework + SPA rewrites for React Router.
- `DEPLOYMENT.md` — end-to-end deploy guide.

## Definition of Done
- [ ] Backend deployed and accessible at a public URL *(manual Render step)*
- [ ] `GET /health` returns 200 from the public URL *(endpoint added; verify post-deploy)*
- [ ] MongoDB Atlas cluster connected and working *(manual Atlas step)*
- [x] All sensitive values set as environment variables (not in code) — `render.yaml` uses `sync: false` / `generateValue: true`; `.env.example` holds placeholders only
- [x] Auto-deploy from `main` branch configured — `render.yaml` `branch: main` + `autoDeployTrigger: checksPass`
- [x] CORS configured for the deployed frontend URL — `ALLOWED_ORIGINS` allow-list wired into `main.go`
- [ ] WebGL build tested against the deployed backend API *(manual, post-deploy)*
- [ ] Public API URL documented in the project README *(see Notes)*

## Pre-PR Checks
- [x] SOLID principles: ✅ Pass — focused config/health/CORS changes, single responsibility.
- [x] Naming conventions: ✅ Pass — Go PascalCase exported field, UPPER_SNAKE env vars.
- [x] Documentation: ✅ Pass — thorough comments + `DEPLOYMENT.md`; no hardcoded secrets.

## Notes
- The remaining unchecked DoD items are **manual Render/Atlas/Vercel actions** (create the service, connect Atlas, set dashboard secrets) and a **post-deploy smoke test** (`/health` 200, WebGL → prod API) — they can't be verified from code.
- **README API URL:** the public `onrender.com` URL isn't known until the service is created. Once live, add it to the README (and set `VITE_API_URL` on Vercel + `ALLOWED_ORIGINS` on Render).
- **Cross-check:** the docker-compose backend healthcheck (added in #86) targets `/api/v1/health`, while Render/this PR uses root `/health`. Confirm both paths resolve to a real route so neither healthcheck fails.
- This issue is co-assigned to Kamelia (DevOps) — the dashboard setup steps are hers to complete.